### PR TITLE
refactor: change try! with ?

### DIFF
--- a/gif-afl/src/main.rs
+++ b/gif-afl/src/main.rs
@@ -19,16 +19,16 @@ fn main() {
     let mut decoder = gif::Decoder::new(file);*/
     decoder.set(gif::ColorOutput::RGBA);
     match (|| -> Result<(), gif::DecodingError> {
-        let mut decoder = try!(decoder.read_info());
+        let mut decoder = decoder.read_info()?;
         println!("width = {}, height = {}", decoder.width(), decoder.height());
         let mut i = 0;
         loop {
-            if let Some(frame) = try!(decoder.next_frame_info()) {
+            if let Some(frame) = decoder.next_frame_info()? {
                 i += 1;
                 println!("frame {}: {:?}", i, frame);
             } else { break }
             let mut vec = vec![0; decoder.buffer_size()];
-            try!(decoder.fill_buffer(&mut vec));
+            decoder.fill_buffer(&mut vec)?;
             test::black_box(vec);
         }
         Ok(())

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -216,7 +216,7 @@ impl<W: Write> Encoder<W> {
             };
             self.w.write_le(min_code_size)?;
             let mut bw = BlockWriter::new(&mut self.w);
-            let mut enc = lzw::Encoder::new(lzw::LsbWriter::new(&mut bw), min_code_size));
+            let mut enc = lzw::Encoder::new(lzw::LsbWriter::new(&mut bw), min_code_size)?;
             enc.encode_bytes(data)?;
         }
         self.w.write_le(0u8)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,9 @@
 // }
 // # (|| {
 // {
-// let mut file = try!(File::create("test.gif"));
+// let mut file = File::create("test.gif")?;
 // let mut encoder = Encoder::new(&mut file, 100, 100);
-// try!(encoder.write_global_palette(color_map)).write_frame(&frame)
+// encoder.write_global_palette(color_map)?.write_frame(&frame)
 // }
 // # })().unwrap();
 // ```

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,7 +56,7 @@ impl<W: io::Write + ?Sized> WriteBytesExt<u16> for W {
 impl<W: io::Write + ?Sized> WriteBytesExt<u32> for W {
     #[inline]
     fn write_le(&mut self, n: u32) -> io::Result<()> {
-        try!(self.write_le(n as u16));
+        self.write_le(n as u16)?;
         self.write_le((n >> 16) as u16)
         
     }
@@ -65,7 +65,7 @@ impl<W: io::Write + ?Sized> WriteBytesExt<u32> for W {
 impl<W: io::Write + ?Sized> WriteBytesExt<u64> for W {
     #[inline]
     fn write_le(&mut self, n: u64) -> io::Result<()> {
-        try!(self.write_le(n as u32));
+        self.write_le(n as u32)?;
         self.write_le((n >> 32) as u32)
         
     }

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -69,11 +69,11 @@ fn error_cast() {
 #[test]
 fn render_images() {
     process_images(|path| {
-        let mut decoder = gif::Decoder::new(try!(File::open(path)));
+        let mut decoder = gif::Decoder::new(File::open(path)?);
         decoder.set(gif::ColorOutput::RGBA);
-        let mut decoder = try!(decoder.read_info());
+        let mut decoder = decoder.read_info()?;
         let mut crc = Crc32::new();
-        while let Some(frame) = try!(decoder.read_next_frame()) {
+        while let Some(frame) = decoder.read_next_frame()? {
             // First sanity check:
             assert_eq!(
                 frame.buffer.len(), 


### PR DESCRIPTION
Started by: [pull/46](https://github.com/image-rs/image-gif/pull/46)

But since [this PR](https://github.com/image-rs/image-gif/commit/120f0e79aa4ca8582f1bc504f6da9726d654545a#diff-354f30a63fb0907d4ad57269548329e3L3) Rust was upgraded to 1.24.1... So we can now replace the `try`.