### PR TITLE
Correctly check background color validity

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -181,7 +181,7 @@ impl<R> Reader<R> where R: Read {
         }
         // If the background color is invalid, ignore it
         if let &Some(ref palette) = &self.global_palette {
-            if self.bg_color.unwrap_or(0) as usize >= palette.len() {
+            if self.bg_color.unwrap_or(0) as usize >= (palette.len() / PLTE_CHANNELS) {
                 self.bg_color = None;
             }
         }


### PR DESCRIPTION
This is a follow-up to #49.

When checking the validity of the background color index, divide the palette length by the number of channels to have the correct number of colors in the palette.