### PR TITLE
Fix code style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.24.1
+  - 1.27.1
   - stable
   - nightly
 env:

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -50,11 +50,12 @@ pub struct ExtensionBlock {
     /// on malloc(3) heap
     pub Bytes: *mut GifByteType, // TODO USE MALLOC for this
     /// The block function code
-    pub Function: c_int, //#define CONTINUE_EXT_FUNC_CODE    0x00    /* continuation subblock */
-                         //#define COMMENT_EXT_FUNC_CODE     0xfe    /* comment */
-                         //#define GRAPHICS_EXT_FUNC_CODE    0xf9    /* graphics control (GIF89) */
-                         //#define PLAINTEXT_EXT_FUNC_CODE   0x01    /* plaintext */
-                         //#define APPLICATION_EXT_FUNC_CODE 0xff    /* application block */
+    pub Function: c_int,
+    //#define CONTINUE_EXT_FUNC_CODE    0x00    /* continuation subblock */
+    //#define COMMENT_EXT_FUNC_CODE     0xfe    /* comment */
+    //#define GRAPHICS_EXT_FUNC_CODE    0xf9    /* graphics control (GIF89) */
+    //#define PLAINTEXT_EXT_FUNC_CODE   0x01    /* plaintext */
+    //#define APPLICATION_EXT_FUNC_CODE 0xff    /* application block */
 }
 
 #[repr(C)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -25,7 +25,7 @@ impl DisposalMethod {
             1 => Some(DisposalMethod::Keep),
             2 => Some(DisposalMethod::Background),
             3 => Some(DisposalMethod::Previous),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -39,7 +39,7 @@ pub enum Block {
     /// Extension block.
     Extension = 0x21,
     /// Image trailer.
-    Trailer = 0x3B
+    Trailer = 0x3B,
 }
 
 impl Block {
@@ -49,11 +49,10 @@ impl Block {
             0x2C => Some(Block::Image),
             0x21 => Some(Block::Extension),
             0x3B => Some(Block::Trailer),
-            _ => None
+            _ => None,
         }
     }
 }
-
 
 /// Known GIF extensions
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -66,7 +65,7 @@ pub enum Extension {
     /// Comment extension.
     Comment = 0xFE,
     /// Application extension.
-    Application = 0xFF
+    Application = 0xFF,
 }
 
 impl Extension {
@@ -77,7 +76,7 @@ impl Extension {
             0xF9 => Some(Extension::Control),
             0xFE => Some(Extension::Comment),
             0xFF => Some(Extension::Application),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -107,7 +106,7 @@ pub struct Frame<'a> {
     pub palette: Option<Vec<u8>>,
     /// Buffer containing the image data.
     /// Only indices unless configured differently.
-    pub buffer: Cow<'a, [u8]>
+    pub buffer: Cow<'a, [u8]>,
 }
 
 impl<'a> Default for Frame<'a> {
@@ -123,7 +122,7 @@ impl<'a> Default for Frame<'a> {
             height: 0,
             interlaced: false,
             palette: None,
-            buffer: Cow::Borrowed(&[])
+            buffer: Cow::Borrowed(&[]),
         }
     }
 }
@@ -146,9 +145,17 @@ impl Frame<'static> {
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height * 4`.
     /// *   If `speed < 1` or `speed > 30`
-    pub fn from_rgba_speed(width: u16, height: u16, pixels: &mut [u8], speed: i32) -> Frame<'static> {
+    pub fn from_rgba_speed(
+        width: u16,
+        height: u16,
+        pixels: &mut [u8],
+        speed: i32,
+    ) -> Frame<'static> {
         assert_eq!(width as usize * height as usize * 4, pixels.len(), "Too much or too little pixel data for the given width and height to create a GIF Frame");
-        assert!(speed >= 1 && speed <= 30, "speed needs to be in the range [1, 30]");
+        assert!(
+            speed >= 1 && speed <= 30,
+            "speed needs to be in the range [1, 30]"
+        );
         let mut frame = Frame::default();
         let mut transparent = None;
         for pix in pixels.chunks_mut(4) {
@@ -177,9 +184,22 @@ impl Frame<'static> {
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height`.
     /// *   If the length of palette > `256 * 3`.
-    pub fn from_palette_pixels(width: u16, height: u16, pixels: &[u8], palette: &[u8], transparent: Option<u8>) -> Frame<'static> {
-        assert_eq!(width as usize * height as usize, pixels.len(), "Too many or too little pixels for the given width and height to create a GIF Frame");
-        assert!(palette.len() <= 256*3, "Too many palette values to create a GIF Frame");
+    pub fn from_palette_pixels(
+        width: u16,
+        height: u16,
+        pixels: &[u8],
+        palette: &[u8],
+        transparent: Option<u8>,
+    ) -> Frame<'static> {
+        assert_eq!(
+            width as usize * height as usize,
+            pixels.len(),
+            "Too many or too little pixels for the given width and height to create a GIF Frame"
+        );
+        assert!(
+            palette.len() <= 256 * 3,
+            "Too many palette values to create a GIF Frame"
+        );
         let mut frame = Frame::default();
 
         frame.width = width;
@@ -197,8 +217,17 @@ impl Frame<'static> {
     ///
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height`.
-    pub fn from_indexed_pixels(width: u16, height: u16, pixels: &[u8], transparent: Option<u8>) -> Frame<'static> {
-        assert_eq!(width as usize * height as usize, pixels.len(), "Too many or too little pixels for the given width and height to create a GIF Frame");
+    pub fn from_indexed_pixels(
+        width: u16,
+        height: u16,
+        pixels: &[u8],
+        transparent: Option<u8>,
+    ) -> Frame<'static> {
+        assert_eq!(
+            width as usize * height as usize,
+            pixels.len(),
+            "Too many or too little pixels for the given width and height to create a GIF Frame"
+        );
         let mut frame = Frame::default();
 
         frame.width = width;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -60,9 +60,9 @@ impl ExtensionData {
         flags |= (needs_user_input as u8) << 1;
         flags |= (dispose as u8) << 2;
         ExtensionData::Control {
-            flags: flags,
-            delay: delay,
-            trns: trns,
+            flags,
+            delay,
+            trns,
         }
     }
 }
@@ -76,7 +76,7 @@ struct BlockWriter<'a, W: Write + 'a> {
 impl<'a, W: Write + 'a> BlockWriter<'a, W> {
     fn new(w: &'a mut W) -> BlockWriter<'a, W> {
         BlockWriter {
-            w: w,
+            w,
             bytes: 0,
             buf: [0; 0xFF],
         }
@@ -100,10 +100,10 @@ impl<'a, W: Write + 'a> Write for BlockWriter<'a, W> {
         Ok(to_copy)
     }
     fn flush(&mut self) -> io::Result<()> {
-        return Err(io::Error::new(
+        Err(io::Error::new(
             io::ErrorKind::Other,
             "Cannot flush a BlockWriter, use `drop` instead.",
-        ));
+        ))
     }
 }
 
@@ -140,10 +140,10 @@ impl<W: Write> Encoder<W> {
     /// if no global palette shall be used an empty slice may be supplied.
     pub fn new(w: W, width: u16, height: u16, global_palette: &[u8]) -> io::Result<Self> {
         Encoder {
-            w: w,
+            w,
             global_palette: false,
-            width: width,
-            height: height,
+            width,
+            height,
         }
         .write_global_palette(global_palette)
     }
@@ -271,7 +271,7 @@ impl<W: Write> Encoder<W> {
             Repetitions(repeat) => {
                 self.w.write_le(Extension::Application as u8)?;
                 self.w.write_le(11u8)?;
-                self.w.write(b"NETSCAPE2.0")?;
+                self.w.write_all(b"NETSCAPE2.0")?;
                 self.w.write_le(3u8)?;
                 self.w.write_le(1u8)?;
                 match repeat {
@@ -324,17 +324,16 @@ impl<W: Write> Drop for Encoder<W> {
 }
 
 // Color table size converted to flag bits
-#[rustfmt::skip]
 fn flag_size(size: usize) -> u8 {
     match size {
-        0  ...2   => 0,
-        3  ...4   => 1,
-        5  ...8   => 2,
-        7  ...16  => 3,
-        17 ...32  => 4,
-        33 ...64  => 5,
-        65 ...128 => 6,
-        129...256 => 7,
+        0  ..=2   => 0,
+        3  ..=4   => 1,
+        5  ..=8   => 2,
+        7  ..=16  => 3,
+        17 ..=32  => 4,
+        33 ..=64  => 5,
+        65 ..=128 => 6,
+        129..=256 => 7,
         _ => 7
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,20 @@
 //! # GIF en- and decoding library [![Build Status](https://travis-ci.org/image-rs/image-gif.svg?branch=master)](https://travis-ci.org/image-rs/image-gif)
-//! 
+//!
 //! GIF en- and decoder written in Rust ([API Documentation](https://docs.rs/gif)).
-//! 
+//!
 //! # GIF encoding and decoding library
-//! 
+//!
 //! This library provides all functions necessary to de- and encode GIF files.
-//! 
+//!
 //! ## High level interface
-//! 
+//!
 //! The high level interface consists of the two types
 //! [`Encoder`](struct.Encoder.html) and [`Decoder`](struct.Decoder.html).
 //! They as builders for the actual en- and decoders and can be used to set various
 //! options beforehand.
-//! 
+//!
 //! ### Decoding GIF files
-//! 
+//!
 //! ```rust
 //! // Open the file
 //! use std::fs::File;
@@ -28,18 +28,18 @@
 //!     // Process every frame
 //! }
 //! ```
-//! 
-//! 
-//! 
+//!
+//!
+//!
 //! ### Encoding GIF files
 //!
 //! The encoder can be used so save simple computer generated images:
-//! 
+//!
 //! ```rust
 //! use gif::{Frame, Encoder, Repeat, SetParameter};
 //! use std::fs::File;
 //! use std::borrow::Cow;
-//! 
+//!
 //! let color_map = &[0xFF, 0xFF, 0xFF, 0, 0, 0];
 //! let (width, height) = (6, 6);
 //! let mut beacon_states = [[
@@ -74,7 +74,7 @@
 //!
 //! ```rust
 //! use std::fs::File;
-//! 
+//!
 //! // Get pixel data from some source
 //! let mut pixels: Vec<u8> = vec![0; 30_000];
 //! // Create frame from data
@@ -86,8 +86,7 @@
 //! encoder.write_frame(&frame).unwrap();
 //! ```
 
-
-//! 
+//!
 //! ## C API
 //!
 //! The C API is unstable and widely untested. It can be activated using the feature flag `c_api`.
@@ -120,33 +119,36 @@
 extern crate libc;
 extern crate lzw;
 
-mod traits;
 mod common;
-mod reader;
 mod encoder;
+mod reader;
+mod traits;
 
-#[cfg(feature = "c_api")]
-mod c_api_utils;
 #[cfg(feature = "c_api")]
 pub mod c_api;
+#[cfg(feature = "c_api")]
+mod c_api_utils;
 
-pub use traits::{SetParameter, Parameter};
-pub use common::{Block, Extension, DisposalMethod, Frame};
+pub use common::{Block, DisposalMethod, Extension, Frame};
+pub use traits::{Parameter, SetParameter};
 
-pub use reader::{StreamingDecoder, Decoded, DecodingError};
 /// StreamingDecoder configuration parameters
-pub use reader::{ColorOutput, MemoryLimit, Extensions};
-pub use reader::{Reader, Decoder};
+pub use reader::{ColorOutput, Extensions, MemoryLimit};
+pub use reader::{Decoded, DecodingError, StreamingDecoder};
+pub use reader::{Decoder, Reader};
 
 pub use encoder::{Encoder, ExtensionData, Repeat};
 
 #[cfg(test)]
 #[test]
 fn round_trip() {
-    use std::io::prelude::*;
     use std::fs::File;
+    use std::io::prelude::*;
     let mut data = vec![];
-    File::open("tests/samples/sample_1.gif").unwrap().read_to_end(&mut data).unwrap();
+    File::open("tests/samples/sample_1.gif")
+        .unwrap()
+        .read_to_end(&mut data)
+        .unwrap();
     let mut decoder = Decoder::new(&*data).read_info().unwrap();
     let palette: Vec<u8> = decoder.palette().unwrap().into();
     let frame = decoder.read_next_frame().unwrap().unwrap();

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -1,16 +1,16 @@
 use std::cmp;
-use std::mem;
 use std::default::Default;
+use std::mem;
 
 use std::io;
 
-use std::fmt;
 use std::error;
+use std::fmt;
 
 use lzw;
 
+use common::{Block, DisposalMethod, Extension, Frame};
 use traits::Parameter;
-use common::{Frame, Block, Extension, DisposalMethod};
 
 /// GIF palettes are RGB
 pub const PLTE_CHANNELS: usize = 3;
@@ -66,7 +66,7 @@ pub enum Extensions {
     Save,
     /// Skips the data of unknown extensions
     /// and extracts the data from known ones
-    Skip
+    Skip,
 }
 
 impl Parameter<StreamingDecoder> for Extensions {
@@ -75,7 +75,6 @@ impl Parameter<StreamingDecoder> for Extensions {
         this.skip_extensions = match self {
             Extensions::Skip => true,
             Extensions::Save => false,
-
         }
     }
 }
@@ -104,7 +103,6 @@ pub enum Decoded<'a> {
     Data(&'a [u8]),
     /// No more data available the current frame.
     DataEnd,
-
 }
 
 /// Internal state of the GIF decoder
@@ -123,7 +121,7 @@ enum State {
     LzwInit(u8),
     DecodeSubBlock(usize),
     FrameDecoded,
-    Trailer
+    Trailer,
 }
 use self::State::*;
 
@@ -188,33 +186,30 @@ impl StreamingDecoder {
             global_color_table: Vec::new(),
             background_color: [0, 0, 0, 0xFF],
             ext: (0, Vec::with_capacity(256), true), // 0xFF + 1 byte length
-            current: None
+            current: None,
         }
     }
-    
-    /// Updates the internal state of the decoder. 
+
+    /// Updates the internal state of the decoder.
     ///
-    /// Returns the number of bytes consumed from the input buffer 
+    /// Returns the number of bytes consumed from the input buffer
     /// and the last decoding result.
-    pub fn update<'a>(&'a mut self, mut buf: &[u8])
-    -> Result<(usize, Decoded<'a>), DecodingError> {
+    pub fn update<'a>(&'a mut self, mut buf: &[u8]) -> Result<(usize, Decoded<'a>), DecodingError> {
         // NOTE: Do not change the function signature without double-checking the
         //       unsafe block!
         let len = buf.len();
         while buf.len() > 0 && self.state.is_some() {
             match self.next_state(buf) {
-                Ok((bytes, Decoded::Nothing)) => {
-                    buf = &buf[bytes..]
-                }
+                Ok((bytes, Decoded::Nothing)) => buf = &buf[bytes..],
                 Ok((bytes, Decoded::Trailer)) => {
                     buf = &buf[bytes..];
-                    break
+                    break;
                 }
                 Ok((bytes, result)) => {
                     buf = &buf[bytes..];
-                    return Ok(
-                        (len-buf.len(), 
-                        // This transmute just casts the lifetime away. Since Rust only 
+                    return Ok((
+                        len - buf.len(),
+                        // This transmute just casts the lifetime away. Since Rust only
                         // has SESE regions, this early return cannot be worked out and
                         // such that the borrow region of self includes the whole block.
                         // The explixit lifetimes in the function signature ensure that
@@ -223,29 +218,26 @@ impl StreamingDecoder {
                         // To check that everything is sound, return the result without
                         // the match (e.g. `return Ok(self.next_state(buf)?)`). If
                         // it compiles the returned lifetime is correct.
-                        unsafe { 
-                            mem::transmute::<Decoded, Decoded>(result)
-                        }
-                    ))
+                        unsafe { mem::transmute::<Decoded, Decoded>(result) },
+                    ));
                 }
-                Err(err) => return Err(err)
+                Err(err) => return Err(err),
             }
         }
-        Ok((len-buf.len(), Decoded::Nothing))
-        
+        Ok((len - buf.len(), Decoded::Nothing))
     }
-    
+
     /// Returns the data of the last extension that has been decoded.
     pub fn last_ext(&self) -> (u8, &[u8], bool) {
         (self.ext.0, &*self.ext.1, self.ext.2)
     }
-    
+
     #[inline(always)]
     /// Current frame info as a mutable ref.
     pub fn current_frame_mut<'a>(&'a mut self) -> &'a mut Frame<'static> {
         self.current.as_mut().unwrap()
     }
-    
+
     #[inline(always)]
     /// Current frame info as a ref.
     pub fn current_frame<'a>(&'a self) -> &'a Frame<'static> {
@@ -265,43 +257,45 @@ impl StreamingDecoder {
     fn next_state<'a>(&'a mut self, buf: &[u8]) -> Result<(usize, Decoded<'a>), DecodingError> {
         macro_rules! goto (
             ($n:expr, $state:expr) => ({
-                self.state = Some($state); 
+                self.state = Some($state);
                 Ok(($n, Decoded::Nothing))
             });
             ($state:expr) => ({
-                self.state = Some($state); 
+                self.state = Some($state);
                 Ok((1, Decoded::Nothing))
             });
             ($n:expr, $state:expr, emit $res:expr) => ({
-                self.state = Some($state); 
+                self.state = Some($state);
                 Ok(($n, $res))
             });
             ($state:expr, emit $res:expr) => ({
-                self.state = Some($state); 
+                self.state = Some($state);
                 Ok((1, $res))
             })
         );
-        
+
         let b = buf[0];
-        
+
         // Driver should ensure that state is never None
         let state = self.state.take().unwrap();
         //println!("{:?}", state);
-        
+
         match state {
-            Magic(i, mut version) => if i < 6 {
-                version[i] = b;
-                goto!(Magic(i+1, version))
-            } else if &version[..3] == b"GIF" {
-                self.version = match &version[3..] {
-                    b"87a" => "87a",
-                    b"89a" => "89a",
-                    _ => return Err(DecodingError::Format("unsupported GIF version"))
-                };
-                goto!(U16Byte1(U16Value::ScreenWidth, b))
-            } else {
-                Err(DecodingError::Format("malformed GIF header"))
-            },
+            Magic(i, mut version) => {
+                if i < 6 {
+                    version[i] = b;
+                    goto!(Magic(i + 1, version))
+                } else if &version[..3] == b"GIF" {
+                    self.version = match &version[3..] {
+                        b"87a" => "87a",
+                        b"89a" => "89a",
+                        _ => return Err(DecodingError::Format("unsupported GIF version")),
+                    };
+                    goto!(U16Byte1(U16Value::ScreenWidth, b))
+                } else {
+                    Err(DecodingError::Format("malformed GIF header"))
+                }
+            }
             U16(next) => goto!(U16Byte1(next, b)),
             U16Byte1(next, value) => {
                 use self::U16Value::*;
@@ -310,29 +304,29 @@ impl StreamingDecoder {
                     (ScreenWidth, width) => {
                         self.width = width;
                         goto!(U16(U16Value::ScreenHeight))
-                    },
+                    }
                     (ScreenHeight, height) => {
                         self.height = height;
                         goto!(Byte(ByteValue::GlobalFlags))
-                    },
+                    }
                     (Delay, delay) => {
                         self.ext.1.push(value as u8);
                         self.ext.1.push(b);
                         self.current_frame_mut().delay = delay;
                         goto!(Byte(ByteValue::TransparentIdx))
-                    },
+                    }
                     (ImageLeft, left) => {
                         self.current_frame_mut().left = left;
                         goto!(U16(U16Value::ImageTop))
-                    },
+                    }
                     (ImageTop, top) => {
                         self.current_frame_mut().top = top;
                         goto!(U16(U16Value::ImageWidth))
-                    },
+                    }
                     (ImageWidth, width) => {
                         self.current_frame_mut().width = width;
                         goto!(U16(U16Value::ImageHeight))
-                    },
+                    }
                     (ImageHeight, height) => {
                         self.current_frame_mut().height = height;
                         goto!(Byte(ByteValue::ImageFlags))
@@ -345,23 +339,21 @@ impl StreamingDecoder {
                     GlobalFlags => {
                         let global_table = b & 0x80 != 0;
                         let entries = if global_table {
-                            let entries = PLTE_CHANNELS*(1 << ((b & 0b111) + 1) as usize);
+                            let entries = PLTE_CHANNELS * (1 << ((b & 0b111) + 1) as usize);
                             self.global_color_table.reserve_exact(entries);
                             entries
                         } else {
                             0usize
                         };
-                        goto!(Byte(Background { table_size: entries }))
-                    },
-                    Background { table_size } => {
-                        goto!(
-                            Byte(AspectRatio { table_size: table_size }),
-                            emit Decoded::BackgroundColor(b)
-                        )
-                    },
-                    AspectRatio { table_size } => {
-                        goto!(GlobalPalette(table_size))
-                    },
+                        goto!(Byte(Background {
+                            table_size: entries
+                        }))
+                    }
+                    Background { table_size } => goto!(
+                        Byte(AspectRatio { table_size: table_size }),
+                        emit Decoded::BackgroundColor(b)
+                    ),
+                    AspectRatio { table_size } => goto!(GlobalPalette(table_size)),
                     ControlFlags => {
                         self.ext.1.push(b);
                         let control_flags = b;
@@ -369,41 +361,38 @@ impl StreamingDecoder {
                             // Set to Some(...), gets overwritten later
                             self.current_frame_mut().transparent = Some(0)
                         }
-                        self.current_frame_mut().needs_user_input =
-                            control_flags & 0b10 != 0;
-                        self.current_frame_mut().dispose = match DisposalMethod::from_u8(
-                            (control_flags & 0b11100) >> 2
-                        ) {
-                            Some(method) => method,
-                            None => DisposalMethod::Any
-                        };
+                        self.current_frame_mut().needs_user_input = control_flags & 0b10 != 0;
+                        self.current_frame_mut().dispose =
+                            match DisposalMethod::from_u8((control_flags & 0b11100) >> 2) {
+                                Some(method) => method,
+                                None => DisposalMethod::Any,
+                            };
                         goto!(U16(U16Value::Delay))
                     }
                     TransparentIdx => {
                         self.ext.1.push(b);
                         if let Some(ref mut idx) = self.current_frame_mut().transparent {
-                             *idx = b
+                            *idx = b
                         }
                         goto!(SkipBlock(0))
                         //goto!(AwaitBlockEnd)
                     }
                     ImageFlags => {
                         let local_table = (b & 0b1000_0000) != 0;
-                        let interlaced   = (b & 0b0100_0000) != 0;
-                        let table_size  =  b & 0b0000_0111;
-                        
+                        let interlaced = (b & 0b0100_0000) != 0;
+                        let table_size = b & 0b0000_0111;
+
                         self.current_frame_mut().interlaced = interlaced;
                         if local_table {
                             let entries = PLTE_CHANNELS * (1 << (table_size + 1));
-                            
-                            self.current_frame_mut().palette =
-                                Some(Vec::with_capacity(entries));
+
+                            self.current_frame_mut().palette = Some(Vec::with_capacity(entries));
                             goto!(LocalPalette(entries))
                         } else {
                             goto!(Byte(CodeSize))
                         }
-                    },
-                    CodeSize => goto!(LzwInit(b))
+                    }
+                    CodeSize => goto!(LzwInit(b)),
                 }
             }
             GlobalPalette(left) => {
@@ -413,11 +402,17 @@ impl StreamingDecoder {
                     goto!(n, GlobalPalette(left - n))
                 } else {
                     let idx = self.background_color[0];
-                    match self.global_color_table.chunks(PLTE_CHANNELS).nth(idx as usize) {
-                        Some(chunk) => for i in 0..PLTE_CHANNELS {
-                            self.background_color[i] = chunk[i]
-                        },
-                        None => self.background_color[0] = 0
+                    match self
+                        .global_color_table
+                        .chunks(PLTE_CHANNELS)
+                        .nth(idx as usize)
+                    {
+                        Some(chunk) => {
+                            for i in 0..PLTE_CHANNELS {
+                                self.background_color[i] = chunk[i]
+                            }
+                        }
+                        None => self.background_color[0] = 0,
                     }
                     goto!(BlockStart(Block::from_u8(b)), emit Decoded::GlobalPalette(
                         mem::replace(&mut self.global_color_table, Vec::new())
@@ -433,10 +428,7 @@ impl StreamingDecoder {
                     }
                     Some(Extension) => goto!(ExtensionBlock(b), emit Decoded::BlockStart(Extension)),
                     Some(Trailer) => goto!(0, State::Trailer, emit Decoded::BlockStart(Trailer)),
-                    None => {
-                        return Err(DecodingError::Format(
-                        "unknown block type encountered"
-                    ))}
+                    None => return Err(DecodingError::Format("unknown block type encountered")),
                 }
             }
             BlockEnd(terminator) => {
@@ -447,9 +439,7 @@ impl StreamingDecoder {
                         goto!(BlockStart(Block::from_u8(b)))
                     }
                 } else {
-                    return Err(DecodingError::Format(
-                        "expected block terminator not found"
-                    ))
+                    return Err(DecodingError::Format("expected block terminator not found"));
                 }
             }
             ExtensionBlock(type_) => {
@@ -459,17 +449,11 @@ impl StreamingDecoder {
                 self.ext.1.push(b);
                 if let Some(ext) = Extension::from_u8(type_) {
                     match ext {
-                        Control => {
-                            goto!(self.read_control_extension(b)?)
-                        }
-                        Text | Comment | Application => {
-                            goto!(SkipBlock(b as usize))
-                        }
+                        Control => goto!(self.read_control_extension(b)?),
+                        Text | Comment | Application => goto!(SkipBlock(b as usize)),
                     }
                 } else {
-                    return Err(DecodingError::Format(
-                        "unknown extention block encountered"
-                    ))
+                    return Err(DecodingError::Format("unknown extention block encountered"));
                 }
             }
             SkipBlock(left) => {
@@ -485,15 +469,16 @@ impl StreamingDecoder {
                         self.ext.2 = false;
                         goto!(SkipBlock(b as usize), emit Decoded::SubBlockFinished(self.ext.0,&self.ext.1))
                     }
-                    
                 }
             }
             LocalPalette(left) => {
                 let n = cmp::min(left, buf.len());
                 if left > 0 {
-                    
-                    self.current_frame_mut().palette
-                        .as_mut().unwrap().extend(buf[..n].iter().cloned());
+                    self.current_frame_mut()
+                        .palette
+                        .as_mut()
+                        .unwrap()
+                        .extend(buf[..n].iter().cloned());
                     goto!(n, LocalPalette(left - n))
                 } else {
                     goto!(LzwInit(b))
@@ -502,9 +487,7 @@ impl StreamingDecoder {
             LzwInit(code_size) => {
                 // LZW spec: max 12 bits per code
                 if code_size > 11 {
-                    return Err(DecodingError::Format(
-                        "invalid minimal code size"
-                    ))
+                    return Err(DecodingError::Format("invalid minimal code size"));
                 }
                 self.lzw_reader = Some(lzw::Decoder::new(lzw::LsbReader::new(), code_size));
                 goto!(DecodeSubBlock(b as usize), emit Decoded::Frame(self.current_frame_mut()))
@@ -515,7 +498,8 @@ impl StreamingDecoder {
                     let decoder = self.lzw_reader.as_mut().unwrap();
                     let (consumed, bytes) = decoder.decode_bytes(&buf[..n])?;
                     goto!(consumed, DecodeSubBlock(left - consumed), emit Decoded::Data(bytes))
-                }  else if b != 0 { // decode next sub-block
+                } else if b != 0 {
+                    // decode next sub-block
                     goto!(DecodeSubBlock(b as usize))
                 } else {
                     // The end of the lzw stream is only reached if left == 0 and an additional call
@@ -531,9 +515,7 @@ impl StreamingDecoder {
                     }
                 }
             }
-            FrameDecoded => {
-                goto!(BlockEnd(b))
-            }
+            FrameDecoded => goto!(BlockEnd(b)),
             Trailer => {
                 self.state = None;
                 Ok((1, Decoded::Trailer))
@@ -541,18 +523,16 @@ impl StreamingDecoder {
             }
         }
     }
-    
+
     fn read_control_extension(&mut self, b: u8) -> Result<State, DecodingError> {
         self.add_frame();
         self.ext.1.push(b);
         if b != 4 {
-            return Err(DecodingError::Format(
-                "control extension has wrong length"
-            ))
+            return Err(DecodingError::Format("control extension has wrong length"));
         }
         Ok(Byte(ByteValue::ControlFlags))
     }
-    
+
     fn add_frame(&mut self) {
         if self.current.is_none() {
             self.current = Some(Frame::default())

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -41,15 +41,13 @@ impl<W: io::Write + ?Sized> WriteBytesExt<u8> for W {
     #[inline]
     fn write_le(&mut self, n: u8) -> io::Result<()> {
         self.write_all(&[n])
-        
     }
 }
 
 impl<W: io::Write + ?Sized> WriteBytesExt<u16> for W {
     #[inline]
     fn write_le(&mut self, n: u16) -> io::Result<()> {
-        self.write_all(&[n as u8, (n>>8) as u8])
-        
+        self.write_all(&[n as u8, (n >> 8) as u8])
     }
 }
 
@@ -58,7 +56,6 @@ impl<W: io::Write + ?Sized> WriteBytesExt<u32> for W {
     fn write_le(&mut self, n: u32) -> io::Result<()> {
         self.write_le(n as u16)?;
         self.write_le((n >> 16) as u16)
-        
     }
 }
 
@@ -67,6 +64,5 @@ impl<W: io::Write + ?Sized> WriteBytesExt<u64> for W {
     fn write_le(&mut self, n: u64) -> io::Result<()> {
         self.write_le(n as u32)?;
         self.write_le((n >> 32) as u32)
-        
     }
 }

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -2,19 +2,21 @@ extern crate gif;
 extern crate glob;
 
 use std::collections::HashMap;
+use std::error::Error;
 use std::fs::File;
 use std::path::PathBuf;
-use std::error::Error;
 
-use std::io::BufReader;
 use std::io::prelude::*;
+use std::io::BufReader;
 
 use gif::SetParameter;
 
 const BASE_PATH: [&'static str; 2] = [".", "tests"];
 
 fn process_images<F>(func: F)
-where F: Fn(PathBuf) -> Result<u32, gif::DecodingError> {
+where
+    F: Fn(PathBuf) -> Result<u32, gif::DecodingError>,
+{
     let base: PathBuf = BASE_PATH.iter().collect();
     let test_suites = &["samples"];
     let mut results = HashMap::new();
@@ -30,12 +32,12 @@ where F: Fn(PathBuf) -> Result<u32, gif::DecodingError> {
                 Ok(crc) => {
                     results.insert(format!("{:?}", path), format!("{}", crc));
                     println!("{}", crc)
-                },
+                }
                 Err(_) if path.file_name().unwrap().to_str().unwrap().starts_with("x") => {
                     expected_failures += 1;
                     println!("Expected failure")
-                },   
-                err => panic!("{:?}", err)
+                }
+                err => panic!("{:?}", err),
             }
         }
     }
@@ -55,7 +57,9 @@ where F: Fn(PathBuf) -> Result<u32, gif::DecodingError> {
     assert_eq!(expected_failures, failures);
     for (path, crc) in results.iter() {
         assert_eq!(
-            ref_results.get(path).expect(&format!("reference for {:?} is missing", path)), 
+            ref_results
+                .get(path)
+                .expect(&format!("reference for {:?} is missing", path)),
             crc
         )
     }
@@ -63,7 +67,7 @@ where F: Fn(PathBuf) -> Result<u32, gif::DecodingError> {
 
 #[test]
 fn error_cast() {
-    let _ : Box<Error> = gif::DecodingError::Internal("testing").into();
+    let _: Box<Error> = gif::DecodingError::Internal("testing").into();
 }
 
 #[test]
@@ -76,10 +80,8 @@ fn render_images() {
         while let Some(frame) = decoder.read_next_frame()? {
             // First sanity check:
             assert_eq!(
-                frame.buffer.len(), 
-                frame.width as usize
-                * frame.height as usize
-                * 4
+                frame.buffer.len(),
+                frame.width as usize * frame.height as usize * 4
             );
             crc.update(&*frame.buffer);
         }
@@ -87,7 +89,7 @@ fn render_images() {
     })
 }
 
-
+#[rustfmt::skip]
 const CRC_TABLE: [u32; 256] = [
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419,
     0x706af48f, 0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4,
@@ -152,9 +154,9 @@ pub struct Crc32 {
 impl Crc32 {
     /// Create a new hasher.
     pub fn new() -> Crc32 {
-        Crc32 {crc: 0xFFFFFFFF}
+        Crc32 { crc: 0xFFFFFFFF }
     }
-    
+
     /// Resets the hasher.
     pub fn reset(&mut self) {
         *self = Self::new()

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -67,7 +67,7 @@ where
 
 #[test]
 fn error_cast() {
-    let _: Box<Error> = gif::DecodingError::Internal("testing").into();
+    let _: Box<dyn Error> = gif::DecodingError::Internal("testing").into();
 }
 
 #[test]
@@ -89,7 +89,6 @@ fn render_images() {
     })
 }
 
-#[rustfmt::skip]
 const CRC_TABLE: [u32; 256] = [
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419,
     0x706af48f, 0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4,


### PR DESCRIPTION
It bumps up minimum supported version to 1.27.1 (for using `dyn` and `..=`).
I avoid using `#[rustfmt:skip]` because it's experimental in that version.