### PR TITLE
Bump version to 0.10.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "gif"
 license = "MIT/Apache-2.0"
-version = "0.10.2"
+version = "0.10.3"
 description = "GIF de- and encoder"
 authors = ["nwin <nwin@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Prepares the respective release. This simply ensures another CI run.