### PR TITLE
Bump minimal supported version to 1.27.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.24.1
+  - 1.27.2
   - stable
   - nightly
 env:


### PR DESCRIPTION
lazy-static, one of the dependencies, supports rustc 1.27.2 or higher so the CI is failing.
This bumps up the minimal supported version (maybe, according to the travis) to 1.27.2.