### PR TITLE
Fixup decoding benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
       cargo build -v --features="$FEATURES";
     else
         cargo test -v --features="$FEATURES";
+        cargo build --benches -v --features="$FEATURES";
     fi

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -61,7 +61,7 @@ fn main() {
     });
 
     run_bench_def(&mut group, BenchDef {
-        data: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/sample_big.gif")),
+        data: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/samples/sample_big.gif")),
         id: "sample_big.gif",
         sample_size: 20,
     });


### PR DESCRIPTION
This got lost when one of the images got moved as part of integrating it
into the reference tests. But travis did not test the build so there was
no notice.