### PR TITLE
Forward compatible blocks

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -115,7 +115,7 @@ impl From<Extension> for AnyExtension {
 }
 
 impl Extension {
-    /// Converts `u8` to a `KnownExtension` if it is known.
+    /// Converts `u8` to a `Extension` if it is known.
     pub fn from_u8(n: u8) -> Option<Extension> {
         match n {
             0x01 => Some(Extension::Text),

--- a/src/common.rs
+++ b/src/common.rs
@@ -30,7 +30,16 @@ impl DisposalMethod {
     }
 }
 
-/// Known GIF block types
+/// Known GIF block labels.
+///
+/// Note that the block uniquely specifies the layout of bytes that follow and how they are
+/// framed. For example, the header always has a fixed length but is followed by a variable amount
+/// of additional data. An image descriptor may be followed by a local color table depending on
+/// information read in it. Therefore, it doesn't make sense to continue parsing after encountering
+/// an unknown block as the semantics of following bytes are unclear.
+///
+/// The extension block provides a common framing for an arbitrary amount of application specific
+/// data which may be ignored.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Block {
@@ -39,7 +48,7 @@ pub enum Block {
     /// Extension block.
     Extension = 0x21,
     /// Image trailer.
-    Trailer = 0x3B
+    Trailer = 0x3B,
 }
 
 impl Block {
@@ -54,23 +63,59 @@ impl Block {
     }
 }
 
+/// A newtype wrapper around an arbitrary extension ID.
+///
+/// An extension is some amount of byte data organized in sub-blocks so that one can skip over it
+/// without knowing the semantics. Though technically you likely want to use a `Application`
+/// extension, the library tries to stay flexible here.
+///
+/// This allows us to customize the set of impls compared to a raw `u8`. It also clarifies the
+/// intent and gives some inherent methods for interoperability with known extension types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AnyExtension(pub u8);
 
-/// Known GIF extensions
+/// Known GIF extension labels.
+///
+/// These are extensions which may be interpreted by the library and to which a specification with
+/// the internal data layout is known.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Extension {
-    /// Text extension.
+    /// Plain Text extension.
+    ///
+    /// This instructs the decoder to render a text as characters in a grid of cells, in a
+    /// mono-spaced font of its choosing. This is seldom actually implemented and ignored by
+    /// ImageMagick. The color is always taken from the global table which further complicates any
+    /// use. No real information on the frame sequencing of this block is available in the
+    /// standard.
     Text = 0x01,
     /// Control extension.
     Control = 0xF9,
     /// Comment extension.
     Comment = 0xFE,
     /// Application extension.
-    Application = 0xFF
+    ///
+    /// See [ImageMagick] for an idea of commonly recognized extensions.
+    ///
+    /// [ImageMagick]: https://github.com/ImageMagick/ImageMagick/blob/b0b58c6303195928060f55f9c3ca8233ab7f7733/coders/gif.c#L1128
+    Application = 0xFF,
+}
+
+impl AnyExtension {
+    /// Decode the label as a known extension.
+    pub fn into_known(self) -> Option<Extension> {
+        Extension::from_u8(self.0)
+    }
+}
+
+impl From<Extension> for AnyExtension {
+    fn from(ext: Extension) -> Self {
+        AnyExtension(ext as u8)
+    }
 }
 
 impl Extension {
-    /// Converts `u8` to `Option<Self>`
+    /// Converts `u8` to a `KnownExtension` if it is known.
     pub fn from_u8(n: u8) -> Option<Extension> {
         match n {
             0x01 => Some(Extension::Text),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -229,7 +229,10 @@ impl<W: Write> Encoder<W> {
         if num_colors > 256 {
             return Err(EncodingError::from(FormatErrorKind::TooManyColors));
         }
+        // Size of global color table.
         flags |= flag_size(num_colors);
+        // Color resolution .. FIXME. This is mostly ignored (by ImageMagick at least) but hey, we
+        // should use some sensible value here or even allow configuring it?
         flags |= flag_size(num_colors) << 4; // wtf flag
         self.write_screen_desc(flags)?;
         self.write_color_table(palette)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ mod common;
 mod reader;
 mod encoder;
 
-pub use crate::common::{Block, Extension, DisposalMethod, Frame};
+pub use crate::common::{AnyExtension, Block, Extension, DisposalMethod, Frame};
 
 pub use crate::reader::{StreamingDecoder, Decoded, DecodingError, DecodingFormatError};
 /// StreamingDecoder configuration parameters

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::iter;
 use std::io::prelude::*;
 
-use crate::common::Frame;
+use crate::common::{Block, Frame};
 
 mod decoder;
 pub use self::decoder::{
@@ -33,7 +33,7 @@ pub enum ColorOutput {
 /// that there is no memory limit set.
 pub struct MemoryLimit(pub u32);
 
-/// GIF decoder
+/// Options for opening a GIF decoder.
 #[derive(Clone, Debug)]
 pub struct DecodeOptions {
     memory_limit: u32,
@@ -88,7 +88,7 @@ impl<R: Read> ReadDecoder<R> {
             self.reader.consume(consumed);
             match result {
                 Decoded::Nothing => (),
-                Decoded::BlockStart(crate::common::Block::Trailer) => {
+                Decoded::BlockStart(Block::Trailer) => {
                     self.at_eof = true
                 },
                 result => return Ok(unsafe{


### PR DESCRIPTION
Make extension IDs into a new type. Also improve the documentation on them. This is mainly meant to give us an 'out' of sorts should we ever need to add inherent methods to the extension ID itself or want to add a Display impl or better formatting for the debug one. This is a breaking change to the `StreamingDecoder` and `Encoder` so now is a good time for small ergonomic improvement.