### PR TITLE
Revisit the frame oob check

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -64,7 +64,7 @@ impl DecodeOptions {
         DecodeOptions {
             memory_limit: MemoryLimit(50_000_000), // 50 MB
             color_output: ColorOutput::Indexed,
-            check_frame_consistency: true,
+            check_frame_consistency: false,
         }
     }
 
@@ -80,12 +80,14 @@ impl DecodeOptions {
 
     /// Configure if frames must be within the screen descriptor.
     ///
-    /// The default is `true`.
+    /// The default is `false`.
     ///
     /// When turned on, all frame descriptors being read must fit within the screen descriptor or
     /// otherwise an error is returned and the stream left in an unspecified state.
     ///
-    /// When turned off, frames may be arbitrarily larger or offset in relation to the screen.
+    /// When turned off, frames may be arbitrarily larger or offset in relation to the screen. Many
+    /// other decoder libraries handle this in highly divergent ways. This moves all checks to the
+    /// caller, for example to emulate a specific style.
     pub fn check_frame_consistency(&mut self, check: bool) {
         self.check_frame_consistency = check;
     }

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -1,0 +1,49 @@
+use gif::{DecodeOptions, DisposalMethod, Encoder, Frame};
+
+#[test]
+fn frame_consistency_is_configurable() {
+    let image = create_image_with_oob_frames();
+    let mut options = DecodeOptions::new();
+
+    {
+        let mut data = image.as_slice();
+        let mut decoder = options.clone().read_info(&mut data).unwrap();
+        assert!(decoder.read_next_frame().is_ok());
+        assert!(decoder.read_next_frame().is_err());
+    }
+
+    {
+        options.check_frame_consistency(false);
+        let mut data = image.as_slice();
+        let mut decoder = options.clone().read_info(&mut data).unwrap();
+        assert!(decoder.read_next_frame().is_ok());
+        assert!(decoder.read_next_frame().is_ok());
+    }
+}
+
+fn create_image_with_oob_frames() -> Vec<u8> {
+    let mut data = vec![];
+    let mut encoder = Encoder::new(&mut data, 2, 2, &[0, 0, 0]).unwrap();
+
+    let mut frame = Frame {
+        delay: 1,
+        dispose: DisposalMethod::Any,
+        transparent: None,
+        needs_user_input: false,
+        top: 0,
+        left: 0,
+        width: 2,
+        height: 2,
+        interlaced: false,
+        palette: None,
+        buffer: vec![0, 0, 0, 0].into(),
+    };
+
+    encoder.write_frame(&frame).unwrap();
+    frame.top = 1;
+    frame.left = 1;
+    encoder.write_frame(&frame).unwrap();
+
+    drop(encoder);
+    data
+}


### PR DESCRIPTION
In particular, allow frames to be out-of-bounds even if the specification states the opposite. This is motivated by a test in `image` asserting such an image to be valid and most other decoders also recognizing it (though with slightly diverging results..). Turning it off effectively offloads all checks to the caller as was the case prior to `0.17`.

At the same time, introduce a more immediate check for the memory allocated for frames when they are read into a new owned buffer. This fixes an issue where the true size could be off by a factor of `4`.