### PR TITLE
Release notes for 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gif"
 license = "MIT/Apache-2.0"
-version = "0.11.0"
+version = "0.11.1"
 description = "GIF de- and encoder"
 authors = ["nwin <nwin@users.noreply.github.com>"]
 readme = "README.md"

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+# v0.11.1
+
+- Frames out-of-bounds of the screen descriptor are again accepted by default.
+- Added `DecodeOptions::check_frame_consistency` to turn this validation on.
+
 # v0.11
 
 - Rename `Reader` to `Decoder`.


### PR DESCRIPTION
This release passes the `image` testsuite again with default options.