### PR TITLE
Make Repeat copyable

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -87,6 +87,7 @@ impl From<FormatErrorKind> for EncodingError {
 
 
 /// Number of repetitions
+#[derive(Copy, Clone, Debug)]
 pub enum Repeat {
     /// Finite number of repetitions
     Finite(u16),


### PR DESCRIPTION
It's just a number, so there's no reason to have it non-copy.