### PR TITLE
Forbid unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@
 // # })().unwrap();
 // ```
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![cfg(feature = "std")]
 
 mod traits;


### PR DESCRIPTION
Pending a benchmark, this removes the last `unsafe` blocks. Those were cause by borrowing checking that only the next generation could fix. Instead, we internally return an owned descriptor and borrow only where necessary.