### PR TITLE
Add support for exact quantisation of images with <= 256 colors

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,6 +2,8 @@
 extern crate color_quant;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 /// Disposal method
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -215,14 +217,14 @@ impl Frame<'static> {
             }
         }
 
-        let nq = color_quant::NeuQuant::new(speed, 256, pixels);
+        let q = quantize(speed, pixels);
 
         Frame {
             width,
             height,
-            buffer: Cow::Owned(pixels.chunks_exact(4).map(|pix| nq.index_of(pix) as u8).collect()),
-            palette: Some(nq.color_map_rgb()),
-            transparent: transparent.map(|t| nq.index_of(&t) as u8),
+            buffer: Cow::Owned(pixels.chunks_exact(4).map(|pix| q.index_of(pix) as u8).collect()),
+            palette: Some(q.color_map_rgb()),
+            transparent: transparent.map(|t| q.index_of(&t) as u8),
             ..Frame::default()
         }
     }
@@ -302,5 +304,54 @@ impl Frame<'static> {
 
     pub(crate) fn required_bytes(&self) -> usize {
         usize::from(self.width) * usize::from(self.height)
+    }
+}
+
+enum Quantizer {
+    // Use NeuQuant for high-colour images...
+    NQ(color_quant::NeuQuant),
+    // And an exact look-up for <= 256 colors.
+    Exact {
+        // Palette look-up table.
+        lookup: HashMap<(u8, u8, u8, u8), usize>,
+        // A palette that can be used by Frame.
+        palette: Vec<u8>,
+    },
+}
+
+impl Quantizer {
+    fn index_of(&self, pixel: &[u8]) -> usize {
+        match self {
+            Quantizer::NQ(nq) => nq.index_of(pixel),
+            Quantizer::Exact { lookup, palette: _ } =>
+                *lookup.get(&(pixel[0], pixel[1], pixel[2], pixel[3])).unwrap(),
+        }
+    }
+
+    fn color_map_rgb(&self) -> Vec<u8> {
+        match self {
+            Quantizer::NQ(nq) => nq.color_map_rgb(),
+            Quantizer::Exact { lookup: _, palette } => palette.clone(),
+        }
+    }
+}
+
+// Attempt to build a palette of all colors. If we go over 256 colors,
+// switch to the NeuQuant algorithm.
+fn quantize(samplefac: i32, pixels: &[u8]) -> Quantizer {
+    let mut colors: HashSet<(u8, u8, u8, u8)> = HashSet::new();
+    for pixel in pixels.chunks_exact(4) {
+        if colors.insert((pixel[0], pixel[1], pixel[2], pixel[3])) && colors.len() > 256 {
+            return Quantizer::NQ(color_quant::NeuQuant::new(samplefac, 256, pixels));
+        }
+    }
+
+    // Palette size <= 256 elements, we can build an exact palette.
+    let mut pixel_vec: Vec<(u8, u8, u8, u8)> = colors.into_iter().collect();
+    pixel_vec.sort();
+
+    Quantizer::Exact {
+        palette: pixel_vec.iter().map(|&(r, g, b, _a)| vec![r, g, b]).flatten().collect(),
+        lookup: pixel_vec.into_iter().zip(0..).collect(),
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -323,7 +323,7 @@ impl Quantizer {
     fn index_of(&self, pixel: &[u8]) -> usize {
         match self {
             Quantizer::NQ(nq) => nq.index_of(pixel),
-            Quantizer::Exact { lookup, palette: _ } =>
+            Quantizer::Exact { lookup, .. } =>
                 *lookup.get(&(pixel[0], pixel[1], pixel[2], pixel[3])).unwrap(),
         }
     }
@@ -331,7 +331,7 @@ impl Quantizer {
     fn color_map_rgb(&self) -> Vec<u8> {
         match self {
             Quantizer::NQ(nq) => nq.color_map_rgb(),
-            Quantizer::Exact { lookup: _, palette } => palette.clone(),
+            Quantizer::Exact { palette, .. } => palette.clone(),
         }
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,4 +1,4 @@
-use gif::{Decoder, Encoder, Frame};
+use gif::{ColorOutput, Decoder, Encoder, Frame};
 
 #[test]
 fn encode_roundtrip() {
@@ -51,5 +51,52 @@ fn round_trip_from_image(original: &[u8]) {
             assert_eq!(new.palette, reference.palette);
             assert_eq!(new.buffer, reference.buffer);
         }
+    }
+}
+
+#[test]
+fn encode_roundtrip_few_colors() {
+    const WIDTH: u16 = 128;
+    const HEIGHT: u16 = 128;
+
+    // Build an image with a single red pixel, that NeuQuant won't
+    // sample, in order to check that we do appropriatelyq specialise the
+    // few-colors case.
+    let mut pixels: Vec<u8> = vec![255; WIDTH as usize * HEIGHT as usize * 4];
+    // Top-left pixel is always sampled, so use the second pixel.
+    pixels[5] = 0;
+    pixels[6] = 0;
+    // Set speed to 30 to handily avoid sampling that one pixel.
+    //
+    // We clone "pixels", since the parameter is replaced with a
+    // paletted version, and later we want to compare the output with
+    // the original RGBA image.
+    let frames = [Frame::from_rgba_speed(WIDTH, HEIGHT, &mut pixels.clone(), 30)];
+
+    let mut buffer = vec![];
+    {
+        let mut encoder = Encoder::new(&mut buffer, WIDTH, HEIGHT, &[]).unwrap();
+        for frame in &frames {
+            encoder.write_frame(frame).unwrap();
+        }
+    }
+
+    {
+        let mut decoder = {
+            let mut builder = Decoder::<&[u8]>::build();
+            builder.set_color_output(ColorOutput::RGBA);
+            builder.read_info(&buffer[..]).expect("Invalid info encoded")
+        };
+
+        // Only check key fields, assuming "round_trip_from_image"
+        // covers the rest. We are primarily concerned with quantisation.
+        assert_eq!(decoder.width(), WIDTH);
+        assert_eq!(decoder.height(), HEIGHT);
+        let new_frames: Vec<_> = core::iter::from_fn(move || {
+            decoder.read_next_frame().unwrap().cloned()
+        }).collect();
+        assert_eq!(new_frames.len(), 1, "Diverging number of frames");
+        // NB: reference.buffer can't be used as it contains the palette version.
+        assert_eq!(new_frames[0].buffer, pixels);
     }
 }


### PR DESCRIPTION
**We detect if an image has <= 256 colors, and if so bypass NeuQuant and generate a palette directly from those colors.**

As a relative Rust newbie, I would particularly appreciate any suggestions on fitting in with the style of the package, and general Rust idioms. This is a first cut that (I believe) does the job, but any feedback appreciated.

## Side issue

One concern I have is around handlng of "transparent". For NeuQuant, it looks to me like if there's multiple colours that have 0 alpha, only one gets selected as transparent, but independently NeuQuant will build an RGBA palette for all the given colours, and of multiple colours with 0 alpha, only one will be mapped to transparent. The others will become visible.

I haven't had time to build a test case, so this only comes from code reading, but it seems suboptimal. I suggest the pre-pass converts all transparent pixels to explicitly the same RGBA value to avoid this issue. I'll be happy to raise another issue and another PR if you agree this is an issue.

For this PR, I've tried to remain consistent with the NeuQuant transparency-handling.

Cheers,
Simon.