### PR TITLE
Version and polish

### DIFF
--- a/examples/check.rs
+++ b/examples/check.rs
@@ -5,7 +5,11 @@ fn main() {
         .unwrap_or_else(|| explain_usage());
     let file = fs::File::open(&file)
         .expect("failed to open input file");
-    let mut reader = gif::Decoder::new(file).unwrap();
+    let mut reader = {
+        let mut options = gif::DecodeOptions::new();
+        options.allow_unknown_blocks(true);
+        options.read_info(file).unwrap()
+    };
 
     loop {
         let frame = match reader.read_next_frame() {

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -1,0 +1,37 @@
+use std::{env, fs, process};
+
+fn main() {
+    let file = env::args().nth(1)
+        .unwrap_or_else(|| explain_usage());
+    let file = fs::File::open(&file)
+        .expect("failed to open input file");
+    let mut reader = gif::Decoder::new(file).unwrap();
+
+    loop {
+        let frame = match reader.read_next_frame() {
+            Ok(Some(frame)) => frame,
+            Ok(None) => break,
+            Err(error) => {
+                println!("Error: {:?}", error);
+                break;
+            }
+        };
+
+        println!(
+            " Frame:\n  \
+                 delay: {:?}\n  \
+                 canvas: {}x{}+{}+{}\n  \
+                 dispose: {:?}\n  \
+                 needs_input: {:?}",
+            frame.delay,
+            frame.width, frame.height, frame.left, frame.top,
+            frame.dispose,
+            frame.needs_user_input
+        );
+    }
+}
+
+fn explain_usage() -> ! {
+    println!("Print information on the frames of a gif.\n\nUsage: check <file>");
+    process::exit(1)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub use crate::common::{AnyExtension, Block, Extension, DisposalMethod, Frame};
 pub use crate::reader::{StreamingDecoder, Decoded, DecodingError, DecodingFormatError};
 /// StreamingDecoder configuration parameters
 pub use crate::reader::{ColorOutput, MemoryLimit, Extensions};
-pub use crate::reader::{DecodeOptions, Decoder};
+pub use crate::reader::{DecodeOptions, Decoder, Version};
 
 pub use crate::encoder::{Encoder, ExtensionData, Repeat, EncodingError};
 

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -323,8 +323,8 @@ impl StreamingDecoder {
 
     /// The version number of the GIF standard used in this image.
     ///
-    /// We suppose a minimum of `V87a` compatibility. This value be reported until we have read the
-    /// version information in the magic header bytes.
+    /// We suppose a minimum of `V87a` compatibility. This value will be reported until we have
+    /// read the version information in the magic header bytes.
     pub fn version(&self) -> Version {
         self.version
     }

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -194,7 +194,7 @@ pub struct StreamingDecoder {
     check_frame_consistency: bool,
     check_for_end_code: bool,
     allow_unknown_blocks: bool,
-    version: &'static str,
+    version: Version,
     width: u16,
     height: u16,
     global_color_table: Vec<u8>,
@@ -203,6 +203,16 @@ pub struct StreamingDecoder {
     ext: ExtensionData,
     /// Frame data
     current: Option<Frame<'static>>,
+}
+
+/// One version number of the GIF standard.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Version {
+    /// Version 87a, from May 1987.
+    V87a,
+    /// Version 89a, from July 1989.
+    V89a,
 }
 
 struct ExtensionData {
@@ -227,7 +237,7 @@ impl StreamingDecoder {
             check_frame_consistency: options.check_frame_consistency,
             check_for_end_code: options.check_for_end_code,
             allow_unknown_blocks: options.allow_unknown_blocks,
-            version: "",
+            version: Version::V87a,
             width: 0,
             height: 0,
             global_color_table: Vec::new(),
@@ -311,7 +321,16 @@ impl StreamingDecoder {
         self.height
     }
 
+    /// The version number of the GIF standard used in this image.
+    ///
+    /// We suppose a minimum of `V87a` compatibility. This value be reported until we have read the
+    /// version information in the magic header bytes.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
     /// Configure whether extensions are saved or skipped.
+    #[deprecated = "Does not work as intended. In fact, doesn't do anything. This may disappear soon."]
     pub fn set_extensions(&mut self, extensions: Extensions) {
         self.skip_extensions = match extensions {
             Extensions::Skip => true,
@@ -351,8 +370,8 @@ impl StreamingDecoder {
                 goto!(Magic(i+1, version))
             } else if &version[..3] == b"GIF" {
                 self.version = match &version[3..] {
-                    b"87a" => "87a",
-                    b"89a" => "89a",
+                    b"87a" => Version::V87a,
+                    b"89a" => Version::V89a,
                     _ => return Err(DecodingError::format("unsupported GIF version"))
                 };
                 goto!(U16Byte1(U16Value::ScreenWidth, b))

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -9,7 +9,8 @@ use crate::common::{Block, Frame};
 
 mod decoder;
 pub use self::decoder::{
-    PLTE_CHANNELS, StreamingDecoder, Decoded, DecodingError, Extensions, DecodingFormatError
+    PLTE_CHANNELS, StreamingDecoder, Decoded, DecodingError, DecodingFormatError, Extensions,
+    Version
 };
 
 const N_CHANNELS: usize = 4;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -30,11 +30,22 @@ pub enum ColorOutput {
 }
 
 #[derive(Clone, Debug)]
-/// Memory limit in bytes. `MemoryLimit::Some(0)` means
+/// Memory limit in bytes. `MemoryLimit(0)` means
 /// that there is no memory limit set.
 pub struct MemoryLimit(pub u32);
 
 impl MemoryLimit {
+    /// Enforce no memory limit.
+    ///
+    /// If you intend to process images from unknown origins this is a potentially dangerous
+    /// constant to use, as your program could be vulnerable to decompression bombs. That is,
+    /// malicious images crafted specifically to require an enormous amount of memory to process
+    /// while having a disproportionately small file size.
+    ///
+    /// The risks for modern machines area bit smaller as the dimensions of each frame can not
+    /// exceed `u32::MAX` (~4Gb) but this is still a significant amount of memory.
+    pub const NONE: MemoryLimit = MemoryLimit(0);
+
     fn buffer_size(&self, color: ColorOutput, width: u16, height: u16) -> Option<usize> {
         let pixels = u32::from(width) * u32::from(height);
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -42,7 +42,7 @@ impl MemoryLimit {
     /// malicious images crafted specifically to require an enormous amount of memory to process
     /// while having a disproportionately small file size.
     ///
-    /// The risks for modern machines area bit smaller as the dimensions of each frame can not
+    /// The risks for modern machines are a bit smaller as the dimensions of each frame can not
     /// exceed `u32::MAX` (~4Gb) but this is still a significant amount of memory.
     pub const NONE: MemoryLimit = MemoryLimit(0);
 


### PR DESCRIPTION
This exposes the version number, acknowledges to the public API that `skip_extensions` does not yet do anything (*cough*, it's been 6 years and no report), and polishes the documentation a bit.