### PR TITLE
Add `Encoder::{get_ref, get_mut}`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -330,6 +330,8 @@ impl<W: Write> Encoder<W> {
     }
 
     /// Gets a mutable reference to the writer instance used by this encoder.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
     pub fn get_mut(&mut self) -> &mut W {
         self.w.as_mut().unwrap()
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -324,6 +324,16 @@ impl<W: Write> Encoder<W> {
         writer.write_le(0u8) // aspect ratio
     }
 
+    /// Gets a reference to the writer instance used by this encoder.
+    pub fn get_ref(&self) -> &W {
+        self.w.as_ref().unwrap()
+    }
+
+    /// Gets a mutable reference to the writer instance used by this encoder.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.w.as_mut().unwrap()
+    }
+
     /// Returns writer instance used by this encoder
     pub fn into_inner(mut self) -> io::Result<W> {
         self.write_trailer()?;


### PR DESCRIPTION
My use case is something akin to streaming: I'd like to encode the frames as they come in, without waiting until all frames are done before getting the result. I can't use a reference as the writer without creating a self-referential struct.

In comparison, `std::io::BufWriter` has [`get_ref`](https://doc.rust-lang.org/std/io/struct.BufWriter.html#method.get_ref) and [`get_mut`](https://doc.rust-lang.org/std/io/struct.BufWriter.html#method.get_mut) in addition to `into_inner`.

About naming: `get_ref` vs `get_inner_ref` vs `get_writer_ref` or something else?