### PR TITLE
Update minimum weezl version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-weezl = "0.1.4"
+weezl = "0.1.5"
 color_quant = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This project uses Encoder::into_vec, which was introduced in v1.5.