### PR TITLE
Fix: stale data across next frame

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -254,6 +254,11 @@ impl<R> Decoder<R> where R: Read {
     
     /// Returns the next frame info
     pub fn next_frame_info(&mut self) -> Result<Option<&Frame<'static>>, DecodingError> {
+        if !self.buffer.is_empty() {
+            // FIXME: Warn about discarding data?
+            self.buffer.clear();
+        }
+
         loop {
             match self.decoder.decode_next()? {
                 Some(Decoded::Frame(frame)) => {


### PR DESCRIPTION
This fixes a decoding error where superfluous image data bytes decoded
in one frame are still present for the next frame. The result is a
pretty corrupt image, if the next frame has a local color matrix then it
appears pretty glitchy, too.

Closes: #130 