### PR TITLE
Add assertion checking against frames with default size

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -177,6 +177,11 @@ impl<W: Write> Encoder<W> {
     ///
     /// Note: This function also writes a control extension if necessary.
     pub fn write_frame(&mut self, frame: &Frame) -> Result<(), EncodingError> {
+        if frame.buffer.len() > 0 {
+            assert_ne!(frame.width, 0, "frame width is zero; perhaps you forgot to fill it in?");
+            assert_ne!(frame.height, 0, "frame height is zero; perhaps you forgot to fill it in?");
+        }
+
         // TODO commented off to pass test in lib.rs
         //if frame.delay > 0 || frame.transparent.is_some() {
             self.write_extension(ExtensionData::new_control_ext(


### PR DESCRIPTION
This bit me once while playing around with the library.
If you do not specify frame dimensions, some decoders will not be able to decode the GIF properly and will simply output a blank image.

The way I implemented it is, you *can* still make zero-sized frames, but the frame buffer must be an empty slice. Maybe that should be changed to a more strict assertion `assert_eq!(frame.buffer.len(), frame.width * frame.height);`? I am not sure how much code this could break.