### PR TITLE
Make color_quant optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         rust: ["1.34.2", stable, beta, nightly]
         features: ["", "std"]
+        features: ["", "std", "color_quant"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         rust: ["1.34.2", stable, beta, nightly]
-        features: ["", "std"]
         features: ["", "std", "color_quant"]
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 
 [dependencies]
 weezl = "0.1.5"
-color_quant = "1.0"
+color_quant = { version = "1.0", optional = true }
 
 [dev-dependencies]
 glob = "0.3"
@@ -27,7 +27,7 @@ criterion = "0.3.1"
 png = "0.17.2"
 
 [features]
-default = ["raii_no_panic", "std"]
+default = ["raii_no_panic", "std", "color_quant"]
 raii_no_panic = []
 # Reservation for a feature turning off std
 std = []
@@ -60,4 +60,4 @@ required-features = ["std"]
 [[bench]]
 name = "rgb_frame"
 harness = false
-required-features = ["std"]
+required-features = ["std, color_quant"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,3 @@
-//! Common common used both by decoder and encoder
-extern crate color_quant;
-
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -187,6 +184,7 @@ impl Frame<'static> {
     ///
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height * 4`.
+    #[cfg(feature = "color_quant")]
     pub fn from_rgba(width: u16, height: u16, pixels: &mut [u8]) -> Frame<'static> {
         Frame::from_rgba_speed(width, height, pixels, 1)
     }
@@ -205,6 +203,7 @@ impl Frame<'static> {
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height * 4`.
     /// *   If `speed < 1` or `speed > 30`
+    #[cfg(feature = "color_quant")]
     pub fn from_rgba_speed(width: u16, height: u16, pixels: &mut [u8], speed: i32) -> Frame<'static> {
         assert_eq!(width as usize * height as usize * 4, pixels.len(), "Too much or too little pixel data for the given width and height to create a GIF Frame");
         assert!(speed >= 1 && speed <= 30, "speed needs to be in the range [1, 30]");
@@ -301,6 +300,7 @@ impl Frame<'static> {
     ///
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height * 3`.
+    #[cfg(feature = "color_quant")]
     pub fn from_rgb(width: u16, height: u16, pixels: &[u8]) -> Frame<'static> {
         Frame::from_rgb_speed(width, height, pixels, 1)
     }
@@ -319,6 +319,7 @@ impl Frame<'static> {
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height * 3`.
     /// *   If `speed < 1` or `speed > 30`
+    #[cfg(feature = "color_quant")]
     pub fn from_rgb_speed(width: u16, height: u16, pixels: &[u8], speed: i32) -> Frame<'static> {
         assert_eq!(width as usize * height as usize * 3, pixels.len(), "Too much or too little pixel data for the given width and height to create a GIF Frame");
         let mut vec: Vec<u8> = Vec::with_capacity(pixels.len() + width as usize * height as usize);
@@ -334,6 +335,7 @@ impl Frame<'static> {
 }
 
 #[test]
+#[cfg(feature = "color_quant")]
 // Creating the `colors_lookup` hashmap in Frame::from_rgba_speed panics due to
 // overflow while bypassing NeuQuant and zipping a RangeFrom with 256 colors.
 // Changing .zip(0_u8..) to .zip(0_u8..=255) fixes this issue.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //! image with a maximum of 256 colors:
 //!
 //! ```rust
+//! # #[cfg(feature = "color_quant")] {
 //! use std::fs::File;
 //! 
 //! // Get pixel data from some source
@@ -82,6 +83,7 @@
 //! let mut encoder = gif::Encoder::new(&mut image, frame.width, frame.height, &[]).unwrap();
 //! // Write frame to file
 //! encoder.write_frame(&frame).unwrap();
+//! # }
 //! ```
 
 // TODO: make this compile
@@ -148,4 +150,5 @@ macro_rules! insert_as_doc {
 }
 
 // Provides the README.md as doc, to ensure the example works!
+#[cfg(feature = "color_quant")]
 insert_as_doc!(include_str!("../README.md"));

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -53,6 +53,7 @@ fn round_trip_from_image(original: &[u8]) {
 }
 
 #[test]
+#[cfg(feature = "color_quant")]
 fn encode_roundtrip_few_colors() {
     const WIDTH: u16 = 128;
     const HEIGHT: u16 = 128;


### PR DESCRIPTION
I'm using pngquant, so I don't need to use another crate. Quantization is also unnecessary when using this crate to only decode gifs.
