### PR TITLE
Allow skipping image decoding

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -68,6 +68,7 @@ pub struct DecodeOptions {
     memory_limit: MemoryLimit,
     color_output: ColorOutput,
     check_frame_consistency: bool,
+    skip_frame_decoding: bool,
     check_for_end_code: bool,
     allow_unknown_blocks: bool,
 }
@@ -79,6 +80,7 @@ impl DecodeOptions {
             memory_limit: MemoryLimit(50_000_000), // 50 MB
             color_output: ColorOutput::Indexed,
             check_frame_consistency: false,
+            skip_frame_decoding: false,
             check_for_end_code: false,
             allow_unknown_blocks: false,
         }
@@ -106,6 +108,17 @@ impl DecodeOptions {
     /// caller, for example to emulate a specific style.
     pub fn check_frame_consistency(&mut self, check: bool) {
         self.check_frame_consistency = check;
+    }
+
+    /// Configure whether to skip decoding frames.
+    ///
+    /// The default is false.
+    ///
+    /// When turned on, LZW decoding is skipped. `Decoder::read_next_frame` will fail, but
+    /// `Decoder::next_frame_info` will return the metadata of the next frame.
+    /// This is useful to count frames without incurring the overhead of decoding.
+    pub fn skip_frame_decoding(&mut self, skip: bool) {
+        self.skip_frame_decoding = skip;
     }
 
     /// Configure if LZW encoded blocks must end with a marker end code.

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -114,8 +114,8 @@ impl DecodeOptions {
     ///
     /// The default is false.
     ///
-    /// When turned on, LZW decoding is skipped. `Decoder::read_next_frame` will fail, but
-    /// `Decoder::next_frame_info` will return the metadata of the next frame.
+    /// When turned on, LZW decoding is skipped. `Decoder::read_next_frame` will return an error
+    /// variant, but `Decoder::next_frame_info` will return the metadata of the next frame.
     /// This is useful to count frames without incurring the overhead of decoding.
     pub fn skip_frame_decoding(&mut self, skip: bool) {
         self.skip_frame_decoding = skip;

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -1,4 +1,4 @@
-use gif::{DecodeOptions, DisposalMethod, Encoder, Frame};
+use gif::{DecodeOptions, DisposalMethod, Encoder, Frame, DecodingError};
 
 #[test]
 fn frame_consistency_is_configurable() {
@@ -96,4 +96,15 @@ fn check_skip_frame_data() {
     }
 
     assert!(matches!(decoder.next_frame_info(), Ok(None)));
+}
+
+#[test]
+fn check_skip_frame_data_decode_frame_error() {
+    let image: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/samples/moon_impact.gif"));
+
+    let mut options = DecodeOptions::new();
+    options.skip_frame_decoding(true);
+    let mut decoder = options.clone().read_info(image).unwrap();
+
+    assert!(matches!(decoder.read_next_frame(), Err(DecodingError::Format(_))));
 }

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -82,3 +82,18 @@ fn check_for_end_code_is_configurable() {
         assert!(decoder.read_next_frame().is_err());
     }
 }
+
+#[test]
+fn check_skip_frame_data() {
+    let image: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/samples/moon_impact.gif"));
+
+    let mut options = DecodeOptions::new();
+    options.skip_frame_decoding(true);
+    let mut decoder = options.clone().read_info(image).unwrap();
+
+    for _ in 0..14 {
+        assert!(matches!(decoder.next_frame_info(), Ok(Some(_))));
+    }
+
+    assert!(matches!(decoder.next_frame_info(), Ok(None)));
+}


### PR DESCRIPTION
When dealing with very large GIFs it may be useful to count the number of frames without decoding. This may be useful when writing a utility like `exiftool` that only cares about the metadata, or if we want to cheaply reject GIFs that are over some size limit without paying for the full decode. The screen size of the GIF is included in the header, but there is no way to count the frames (and therefore the overall size) without iterating through the file.

This PR adds a flag to `DecodeOptions` that allows this.