### PR TITLE
Smaller read_into_buffer

### DIFF
--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -20,18 +20,25 @@ pub struct DecodingFormatError {
 }
 
 impl fmt::Display for DecodingFormatError {
+    #[cold]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.underlying, fmt)
     }
 }
 
 impl error::Error for DecodingFormatError {
+    #[cold]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         Some(&*self.underlying as _)
     }
 }
 
 impl DecodingFormatError {
+    // Cold hints the optimizer that the error paths are less likely.
+    //
+    // This function isn't inlined to reduce code size
+    // when it's often used with a string literal.
+    #[cold]
     fn new(
         err: impl Into<Box<dyn error::Error + Send + Sync>>,
     ) -> Self {
@@ -60,6 +67,7 @@ impl DecodingError {
 }
 
 impl fmt::Display for DecodingError {
+    #[cold]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DecodingError::Format(ref d) => d.fmt(fmt),
@@ -69,6 +77,7 @@ impl fmt::Display for DecodingError {
 }
 
 impl error::Error for DecodingError {
+    #[cold]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             DecodingError::Format(ref err) => Some(err),
@@ -78,12 +87,14 @@ impl error::Error for DecodingError {
 }
 
 impl From<io::Error> for DecodingError {
+    #[inline]
     fn from(err: io::Error) -> Self {
         DecodingError::Io(err)
     }
 }
 
 impl From<DecodingFormatError> for DecodingError {
+    #[inline]
     fn from(err: DecodingFormatError) -> Self {
         DecodingError::Format(err)
     }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -454,6 +454,7 @@ struct InterlaceIterator {
 impl iter::Iterator for InterlaceIterator {
     type Item = usize;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.len == 0 || self.pass > 3 {
             return None

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -316,12 +316,15 @@ impl<R> Decoder<R> where R: Read {
             let width = self.line_length();
             let height = self.current_frame.height as usize;
             for row in (InterlaceIterator { len: height, next: 0, pass: 0 }) {
-                if !self.fill_buffer(&mut buf[row*width..][..width])? {
+                let start = row * width;
+                // Handle a too-small buffer without panicking
+                let line = buf.get_mut(start .. start + width).ok_or_else(|| DecodingError::format("buffer too small"))?;
+                if !self.fill_buffer(line)? {
                     return Err(DecodingError::format("image truncated"))
                 }
             }
         } else {
-            let buf = &mut buf[..self.buffer_size()];
+            let buf = buf.get_mut(..self.buffer_size()).ok_or_else(|| DecodingError::format("buffer too small"))?;
             if !self.fill_buffer(buf)? {
                 return Err(DecodingError::format("image truncated"))
             }
@@ -456,12 +459,15 @@ impl iter::Iterator for InterlaceIterator {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.len == 0 || self.pass > 3 {
-            return None
+        if self.len == 0 {
+            return None;
         }
-        let mut next = self.next + [8, 8, 4, 2][self.pass];
+        // although the pass never goes out of bounds thanks to len==0,
+        // the optimizer doesn't see it. get()? avoids costlier panicking code.
+        let mut next = self.next + *[8, 8, 4, 2].get(self.pass)?;
         while next >= self.len {
-            next = [4, 2, 1, 0][self.pass];
+            debug_assert!(self.pass < 4);
+            next = *[4, 2, 1, 0].get(self.pass)?;
             self.pass += 1;
         }
         mem::swap(&mut next, &mut self.next);


### PR DESCRIPTION
`#[cold]` on boxing function cuts a bunch of duplicate alloc-error-handling code from error paths, and `get()?` optimizes better than panicking `[]`.