### PR TITLE
Increase MSRV to 1.60

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.34.2", stable, beta, nightly]
+        rust: ["1.60.0", stable, beta, nightly]
         features: ["", "std", "color_quant"]
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     - name: test
       run: >
         cargo test --tests --benches --no-default-features --features "$FEATURES"
-      if: ${{ matrix.rust != '1.34.2' }}
+      if: ${{ matrix.rust != '1.60.0' }}
       env:
         FEATURES: ${{ matrix.features }}
   rustfmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 homepage = "https://github.com/image-rs/image-gif"
 repository = "https://github.com/image-rs/image-gif"
 documentation = "https://docs.rs/gif"
-edition = "2018"
+edition = "2021"
 exclude = [
     "tests/crashtest/*",
     "tests/samples/*",
@@ -31,6 +31,7 @@ png = "0.17.2"
 [features]
 default = ["raii_no_panic", "std", "color_quant"]
 raii_no_panic = []
+color_quant = ["dep:color_quant"]
 # Reservation for a feature turning off std
 std = []
 

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -26,7 +26,7 @@ fn main() {
         sample_size: usize,
     }
 
-    fn run_bench_def<M: Measurement>(group: &mut BenchmarkGroup<M>, def: BenchDef) {
+    fn run_bench_def<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, def: BenchDef) {
         group
             .sample_size(def.sample_size)
             .throughput(Throughput::Bytes(def.data.len() as u64))

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -50,7 +50,7 @@ pub enum EncodingError {
 }
 
 impl fmt::Display for EncodingError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EncodingError::Io(err) => err.fmt(fmt),
             EncodingError::Format(err) => err.fmt(fmt),
@@ -177,12 +177,12 @@ impl<W: Write> Encoder<W> {
     /// Writes a frame to the image.
     ///
     /// Note: This function also writes a control extension if necessary.
-    pub fn write_frame(&mut self, frame: &Frame) -> Result<(), EncodingError> {
+    pub fn write_frame(&mut self, frame: &Frame<'_>) -> Result<(), EncodingError> {
         self.write_frame_header(frame)?;
         self.write_image_block(&frame.buffer)
     }
 
-    fn write_frame_header(&mut self, frame: &Frame) -> Result<(), EncodingError> {
+    fn write_frame_header(&mut self, frame: &Frame<'_>) -> Result<(), EncodingError> {
         // TODO commented off to pass test in lib.rs
         //if frame.delay > 0 || frame.transparent.is_some() {
             self.write_extension(ExtensionData::new_control_ext(
@@ -321,7 +321,7 @@ impl<W: Write> Encoder<W> {
     /// from [`Frame::make_lzw_pre_encoded`].
     ///
     /// Note: This function also writes a control extension if necessary.
-    pub fn write_lzw_pre_encoded_frame(&mut self, frame: &Frame) -> Result<(), EncodingError> {
+    pub fn write_lzw_pre_encoded_frame(&mut self, frame: &Frame<'_>) -> Result<(), EncodingError> {
         // empty data is allowed
         if let Some(&min_code_size) = frame.buffer.get(0) {
             if min_code_size > 11 || min_code_size < 2 {

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -68,7 +68,7 @@ impl DecodingError {
 
 impl fmt::Display for DecodingError {
     #[cold]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DecodingError::Format(ref d) => d.fmt(fmt),
             DecodingError::Io(ref err) => err.fmt(fmt),
@@ -350,7 +350,7 @@ impl StreamingDecoder {
                         // the match (e.g. `return Ok(self.next_state(buf)?)`). If
                         // it compiles the returned lifetime is correct.
                         unsafe { 
-                            mem::transmute::<Decoded, Decoded>(result)
+                            mem::transmute::<Decoded<'_>, Decoded<'a>>(result)
                         }
                     ))
                 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -174,7 +174,7 @@ struct ReadDecoder<R: Read> {
 }
 
 impl<R: Read> ReadDecoder<R> {
-    fn decode_next(&mut self, mut decode_bytes_into: Option<&mut [u8]>) -> Result<Option<Decoded>, DecodingError> {
+    fn decode_next(&mut self, mut decode_bytes_into: Option<&mut [u8]>) -> Result<Option<Decoded<'_>>, DecodingError> {
         while !self.at_eof {
             let (consumed, result) = {
                 let buf = self.reader.fill_buf()?;
@@ -193,7 +193,7 @@ impl<R: Read> ReadDecoder<R> {
                 },
                 result => return Ok(unsafe{
                     // FIXME: #6393
-                    Some(mem::transmute::<Decoded, Decoded>(result))
+                    Some(mem::transmute::<Decoded<'_>, Decoded<'_>>(result))
                 }),
             }
         }

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -1,5 +1,3 @@
-extern crate gif;
-extern crate glob;
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -8,7 +8,7 @@ fn encode_roundtrip() {
 
 fn round_trip_from_image(original: &[u8]) {
     let (width, height, global_palette);
-    let frames: Vec<Frame> = {
+    let frames: Vec<_> = {
         let mut decoder = Decoder::new(original).unwrap();
         width = decoder.width();
         height = decoder.height();


### PR DESCRIPTION
Due to use of a 1.53 feature in color_quant (#142) the MSRV was already de-facto higher. Most libraries don't support [anything below 1.56](https://lib.rs/stats#rustc) (2021 edition) and 99% of Rust users are on [1.63 or later](https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/cargo.20version.20usage/near/401440149).


I suggest bumping to 1.60, because this can be done without immediately breaking users on older Rust versions. When a crate version uses the new `dep:` feature syntax, it ends up having a new field in the crates.io registry index, which causes Cargo versions older than 1.60 to silently skip and ignore it, and fall back to an older version if possible. So a release bumped to MSRV 1.60+ will be invisible to users of older Rust versions.

