### PR TITLE
Bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gif"
 license = "MIT/Apache-2.0"
-version = "0.12.0"
+version = "0.13.0"
 description = "GIF de- and encoder"
 authors = ["The image-rs Developers"]
 readme = "README.md"
@@ -20,16 +20,18 @@ exclude = [
 bench = false
 
 [dependencies]
-weezl = "0.1.5"
-color_quant = { version = "1.0", optional = true }
+weezl = "0.1.7"
+color_quant = { version = "1.1", optional = true }
 
 [dev-dependencies]
 glob = "0.3"
-criterion = "0.3.1"
-png = "0.17.2"
+criterion = "0.5.1"
+png = "0.17.10"
 
 [features]
 default = ["raii_no_panic", "std", "color_quant"]
+# The `Encoder` finishes writing in `Drop`, and if the write fails, it either ignores the error (`raii_no_panic`) or panics.
+# Use `Encoder::into_inner` to avoid the issue entirely
 raii_no_panic = []
 color_quant = ["dep:color_quant"]
 # Reservation for a feature turning off std


### PR DESCRIPTION
The `Decoded` enum has changed, and it's unfortunately part of the public API, so it needs semver-major bump.