### PR TITLE
Let decoder return the reader

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -286,7 +286,7 @@ impl<R> Decoder<R> where R: Read {
                 Some(Decoded::Repetitions(repeat)) => {
                     self.repeat = repeat;
                 },
-                Some(Decoded::HeaderEnd | Decoded::Trailer) => {
+                Some(Decoded::HeaderEnd) => {
                     break
                 },
                 Some(_) => {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -220,6 +220,10 @@ impl<R: Read> ReadDecoder<R> {
         }
         Ok(None)
     }
+
+    fn into_inner(self) -> io::BufReader<R> {
+        self.reader
+    }
 }
 
 #[allow(dead_code)]
@@ -477,7 +481,7 @@ impl<R> Decoder<R> where R: Read {
         }
     }
 
-    /// Returns the color palette relevant for the current (next) frame
+    /// Returns the color palette relevant for the frame that has been decoded
     pub fn palette(&self) -> Result<&[u8], DecodingError> {
         // TODO prevent planic
         Ok(match self.current_frame.palette {
@@ -503,7 +507,15 @@ impl<R> Decoder<R> where R: Read {
         self.decoder.decoder.height()
     }
 
+    /// Abort decoding and recover the `io::Read` instance
+    pub fn into_inner(self) -> io::BufReader<R> {
+        self.decoder.into_inner()
+    }
+
     /// Index of the background color in the global palette
+    ///
+    /// In practice this is not used, and the background is
+    /// always transparent
     pub fn bg_color(&self) -> Option<usize> {
         self.bg_color.map(|v| v as usize)
     }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -35,7 +35,7 @@ fn round_trip_from_image(original: &[u8]) {
         assert_eq!(decoder.height(), height);
         assert_eq!(decoder.repeat(), repeat);
         assert_eq!(global_palette, decoder.global_palette().unwrap_or_default());
-        let new_frames: Vec<_> = core::iter::from_fn(move || {
+        let new_frames: Vec<_> = core::iter::from_fn(|| {
             decoder.read_next_frame().unwrap().cloned()
         }).collect();
         assert_eq!(new_frames.len(), frames.len(), "Diverging number of frames");
@@ -52,6 +52,7 @@ fn round_trip_from_image(original: &[u8]) {
             assert_eq!(new.palette, reference.palette);
             assert_eq!(new.buffer, reference.buffer);
         }
+        assert_eq!(0, decoder.into_inner().buffer().len());
     }
 }
 


### PR DESCRIPTION
* Fixes consuming of the last byte in the stream
* `BlockEnd` doesn't need to check the terminator, because it's only set when it can't fail