### PR TITLE
Iterator interface

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -381,7 +381,8 @@ impl Frame<'_> {
     ///
     /// Frames can be compressed in any order, separately from the `Encoder`, which can be used to compress frames in parallel.
     pub fn make_lzw_pre_encoded(&mut self) {
-        let mut buffer = Vec::with_capacity(self.buffer.len() / 2);
+        let mut buffer = Vec::new();
+        buffer.try_reserve(self.buffer.len() / 2).expect("OOM");
         lzw_encode(&self.buffer, &mut buffer);
         self.buffer = Cow::Owned(buffer);
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -350,7 +350,7 @@ impl<W: Write> Encoder<W> {
         self.w.as_mut().unwrap()
     }
 
-    /// Returns writer instance used by this encoder
+    /// Finishes writing, and returns the `io::Write` instance used by this encoder
     pub fn into_inner(mut self) -> io::Result<W> {
         self.write_trailer()?;
         Ok(self.w.take().unwrap())

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -363,9 +363,6 @@ impl StreamingDecoder {
                 return self.next_state(buf, write_into);
             }
 
-            // It's not necessary to check here whether state is `Some`,
-            // because `next_state` checks it anyway, and will return `DecodeError`
-            // if the state has already been set to `None`.
             match self.next_state(buf, write_into) {
                 Ok((bytes, Decoded::Nothing)) => {
                     buf = &buf[bytes..];

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -6,6 +6,12 @@ fn encode_roundtrip() {
     round_trip_from_image(ORIGINAL);
 }
 
+#[test]
+fn encode_roundtrip2() {
+    const ORIGINAL: &[u8] = include_bytes!("samples/interlaced.gif");
+    round_trip_from_image(ORIGINAL);
+}
+
 fn round_trip_from_image(original: &[u8]) {
     let (width, height, global_palette, repeat);
     let frames: Vec<_> = {


### PR DESCRIPTION
It's possible to move the buffer instead of referencing, which makes returning owned frames possible, and relatively cheap.