### PR TITLE
Debug assert zero-sized frames

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,8 @@ Other changes:
  - Enforced memory limit also on metadata extension blocks, and added out-of-memory checks where possible.
  - `EncodingFormatError` enum is public.
  - Removed defunct `skip_extensions`
+ - Added validation of frame dimensions. The buffer must be large enough for all pixels,
+   and if the width or height is 0, the buffer must be empty.
 
 # v0.12.0
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -175,6 +175,7 @@ impl<W: Write> Encoder<W> {
         if frame.buffer.len() < usize::from(frame.width) * usize::from(frame.height) {
             return Err(io::Error::new(io::ErrorKind::InvalidInput, "frame.buffer is too small for its width/height").into());
         }
+        debug_assert!((frame.width > 0 && frame.height > 0) || frame.buffer.is_empty(), "the frame has 0 pixels, but non-empty buffer");
         self.write_frame_header(frame)?;
         self.write_image_block(&frame.buffer)
     }


### PR DESCRIPTION
There are probably real-world broken GIF files with 0-sized frames, and this could affect users transcoding such files, so I don't want to make it a hard error. But it may be a debug assert, catching programming errors, and making handling of it the application's problem.

Fixes #135