### PR TITLE
Use on-stack buffer to avoid single-byte writes

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@ pub trait WriteBytesExt<T> {
 }
 
 impl<W: io::Write + ?Sized> WriteBytesExt<u8> for W {
-    #[inline]
+    #[inline(always)]
     fn write_le(&mut self, n: u8) -> io::Result<()> {
         self.write_all(&[n])
     }


### PR DESCRIPTION
30% reduction in code size, and less penalty for not using BufWrite. 