### PR TITLE
Fix writing palettes with non-power-of-two sizes

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
-use std::collections::HashSet;
+#[cfg(feature = "color_quant")]
+use std::collections::{HashMap, HashSet};
 
 /// Disposal method
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub mod streaming_decoder {
     pub use crate::reader::{Decoded, FrameDataType, FrameDecoder, OutputBuffer, StreamingDecoder};
 }
 
+#[cfg(feature = "color_quant")]
 macro_rules! insert_as_doc {
     { $content:expr } => {
         #[allow(unused_doc_comments)]


### PR DESCRIPTION
I've tested it by reencoding thousands of gifs, but of course all of them had a power-of-two palette.