### PR TITLE
Tidy `std::io::Error` Usage

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -37,9 +37,15 @@ impl fmt::Display for EncodingFormatError {
     }
 }
 
-#[derive(Debug)]
 /// Encoding error.
+#[derive(Debug)]
 pub enum EncodingError {
+    /// Frame buffer is too small for the declared dimensions.
+    FrameBufferTooSmallForDimensions,
+    /// Failed to internally allocate a buffer of sufficient size.
+    OutOfMemory,
+    /// Expected a writer but none found.
+    WriterNotFound,
     /// Returned if the to image is not encodable as a gif.
     Format(EncodingFormatError),
     /// Wraps `std::io::Error`.
@@ -50,6 +56,11 @@ impl fmt::Display for EncodingError {
     #[cold]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::FrameBufferTooSmallForDimensions => {
+                fmt.write_str("Frame Buffer Too Small for Dimensions")
+            }
+            Self::OutOfMemory => fmt.write_str("Out of Memory"),
+            Self::WriterNotFound => fmt.write_str("Writer Not Found"),
             Self::Io(err) => err.fmt(fmt),
             Self::Format(err) => err.fmt(fmt),
         }
@@ -60,6 +71,9 @@ impl error::Error for EncodingError {
     #[cold]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
+            Self::FrameBufferTooSmallForDimensions => None,
+            Self::OutOfMemory => None,
+            Self::WriterNotFound => None,
             Self::Io(err) => Some(err),
             Self::Format(err) => Some(err),
         }
@@ -186,11 +200,7 @@ impl<W: Write> Encoder<W> {
             .checked_mul(usize::from(frame.height))
             .map_or(true, |size| frame.buffer.len() < size)
         {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "frame.buffer is too small for its width/height",
-            )
-            .into());
+            return Err(EncodingError::FrameBufferTooSmallForDimensions);
         }
         debug_assert!(
             (frame.width > 0 && frame.height > 0) || frame.buffer.is_empty(),
@@ -244,13 +254,10 @@ impl<W: Write> Encoder<W> {
         self.buffer.clear();
         self.buffer
             .try_reserve(data.len() / 4)
-            .map_err(|_| io::Error::from(io::ErrorKind::OutOfMemory))?;
+            .map_err(|_| EncodingError::OutOfMemory)?;
         lzw_encode(data, &mut self.buffer);
 
-        let writer = self
-            .w
-            .as_mut()
-            .ok_or(io::Error::from(io::ErrorKind::Unsupported))?;
+        let writer = self.w.as_mut().ok_or(EncodingError::WriterNotFound)?;
         Self::write_encoded_image_block(writer, &self.buffer)
     }
 
@@ -344,7 +351,11 @@ impl<W: Write> Encoder<W> {
     /// This method can be used to write an unsupported extension to the file. `func` is the extension
     /// identifier (e.g. `Extension::Application as u8`). `data` are the extension payload blocks. If any
     /// contained slice has a lenght > 255 it is automatically divided into sub-blocks.
-    pub fn write_raw_extension(&mut self, func: AnyExtension, data: &[&[u8]]) -> io::Result<()> {
+    pub fn write_raw_extension(
+        &mut self,
+        func: AnyExtension,
+        data: &[&[u8]],
+    ) -> Result<(), EncodingError> {
         let writer = self.writer()?;
         writer.write_le(Block::Extension as u8)?;
         writer.write_le(func.0)?;
@@ -354,7 +365,7 @@ impl<W: Write> Encoder<W> {
                 writer.write_all(chunk)?;
             }
         }
-        writer.write_le(0u8)
+        Ok(writer.write_le(0u8)?)
     }
 
     /// Writes a frame to the image, but expects `Frame.buffer` to contain LZW-encoded data
@@ -377,7 +388,7 @@ impl<W: Write> Encoder<W> {
     }
 
     /// Writes the logical screen desriptor
-    fn write_screen_desc(&mut self, flags: u8) -> io::Result<()> {
+    fn write_screen_desc(&mut self, flags: u8) -> Result<(), EncodingError> {
         let mut tmp = tmp_buf::<13>();
         tmp.write_all(b"GIF89a")?;
         tmp.write_le(self.width)?;
@@ -385,7 +396,7 @@ impl<W: Write> Encoder<W> {
         tmp.write_le(flags)?; // packed field
         tmp.write_le(0u8)?; // bg index
         tmp.write_le(0u8)?; // aspect ratio
-        tmp.finish(self.writer()?)
+        Ok(tmp.finish(self.writer()?)?)
     }
 
     /// Gets a reference to the writer instance used by this encoder.
@@ -401,23 +412,19 @@ impl<W: Write> Encoder<W> {
     }
 
     /// Finishes writing, and returns the `io::Write` instance used by this encoder
-    pub fn into_inner(mut self) -> io::Result<W> {
+    pub fn into_inner(mut self) -> Result<W, EncodingError> {
         self.write_trailer()?;
-        self.w
-            .take()
-            .ok_or(io::Error::from(io::ErrorKind::Unsupported))
+        self.w.take().ok_or(EncodingError::WriterNotFound)
     }
 
     /// Write the final tailer.
-    fn write_trailer(&mut self) -> io::Result<()> {
-        self.writer()?.write_le(Block::Trailer as u8)
+    fn write_trailer(&mut self) -> Result<(), EncodingError> {
+        Ok(self.writer()?.write_le(Block::Trailer as u8)?)
     }
 
     #[inline]
-    fn writer(&mut self) -> io::Result<&mut W> {
-        self.w
-            .as_mut()
-            .ok_or(io::Error::from(io::ErrorKind::Unsupported))
+    fn writer(&mut self) -> Result<&mut W, EncodingError> {
+        self.w.as_mut().ok_or(EncodingError::WriterNotFound)
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -39,6 +39,7 @@ impl fmt::Display for EncodingFormatError {
 
 /// Encoding error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum EncodingError {
     /// Frame buffer is too small for the declared dimensions.
     FrameBufferTooSmallForDimensions,

--- a/src/reader/converter.rs
+++ b/src/reader/converter.rs
@@ -1,7 +1,6 @@
 use crate::common::Frame;
 use crate::MemoryLimit;
 use std::borrow::Cow;
-use std::io;
 use std::iter;
 use std::mem;
 
@@ -48,7 +47,7 @@ impl PixelConverter {
         let pixel_bytes = self
             .memory_limit
             .buffer_size(self.color_output, frame.width, frame.height)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::OutOfMemory, "image is too large"))?;
+            .ok_or_else(|| DecodingError::OutOfMemory)?;
 
         debug_assert_eq!(
             pixel_bytes,

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -39,6 +39,7 @@ impl error::Error for DecodingFormatError {
 
 /// Decoding error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DecodingError {
     /// Failed to internally allocate a buffer of sufficient size.
     OutOfMemory,

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -37,9 +37,19 @@ impl error::Error for DecodingFormatError {
     }
 }
 
-#[derive(Debug)]
 /// Decoding error.
+#[derive(Debug)]
 pub enum DecodingError {
+    /// Failed to internally allocate a buffer of sufficient size.
+    OutOfMemory,
+    /// Expected a decoder but none found.
+    DecoderNotFound,
+    /// Expected an end-code, but none found.
+    EndCodeNotFound,
+    /// Decoding could not complete as the reader completed prematurely.
+    UnexpectedEof,
+    /// Error encountered while decoding an LZW stream.
+    LzwError(LzwError),
     /// Returned if the image is found to be malformed.
     Format(DecodingFormatError),
     /// Wraps `std::io::Error`.
@@ -59,6 +69,11 @@ impl fmt::Display for DecodingError {
     #[cold]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
+            Self::OutOfMemory => fmt.write_str("Out of Memory"),
+            Self::DecoderNotFound => fmt.write_str("Decoder Not Found"),
+            Self::EndCodeNotFound => fmt.write_str("End-Code Not Found"),
+            Self::UnexpectedEof => fmt.write_str("Unexpected End of File"),
+            Self::LzwError(ref err) => err.fmt(fmt),
             Self::Format(ref d) => d.fmt(fmt),
             Self::Io(ref err) => err.fmt(fmt),
         }
@@ -69,9 +84,21 @@ impl error::Error for DecodingError {
     #[cold]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
+            Self::OutOfMemory => None,
+            Self::DecoderNotFound => None,
+            Self::EndCodeNotFound => None,
+            Self::UnexpectedEof => None,
+            Self::LzwError(ref err) => Some(err),
             Self::Format(ref err) => Some(err),
             Self::Io(ref err) => Some(err),
         }
+    }
+}
+
+impl From<LzwError> for DecodingError {
+    #[inline]
+    fn from(err: LzwError) -> Self {
+        Self::LzwError(err)
     }
 }
 
@@ -79,13 +106,6 @@ impl From<io::Error> for DecodingError {
     #[inline]
     fn from(err: io::Error) -> Self {
         Self::Io(err)
-    }
-}
-
-impl From<io::ErrorKind> for DecodingError {
-    #[cold]
-    fn from(err: io::ErrorKind) -> Self {
-        Self::Io(io::Error::from(err))
     }
 }
 
@@ -391,7 +411,7 @@ impl OutputBuffer<'_> {
                 let len = buf.len();
                 memory_limit.check_size(vec.len() + len)?;
                 vec.try_reserve(len)
-                    .map_err(|_| io::ErrorKind::OutOfMemory)?;
+                    .map_err(|_| DecodingError::OutOfMemory)?;
                 if vec.capacity() - vec.len() >= len {
                     vec.extend_from_slice(buf);
                 }
@@ -559,7 +579,7 @@ impl StreamingDecoder {
             })
         );
 
-        let b = *buf.first().ok_or(io::ErrorKind::UnexpectedEof)?;
+        let b = *buf.first().ok_or(DecodingError::UnexpectedEof)?;
 
         match self.state {
             Magic => {
@@ -586,7 +606,7 @@ impl StreamingDecoder {
                     let table_size = PLTE_CHANNELS * (1 << ((global_flags & 0b111) + 1) as usize);
                     self.global_color_table
                         .try_reserve_exact(table_size)
-                        .map_err(|_| io::ErrorKind::OutOfMemory)?;
+                        .map_err(|_| DecodingError::OutOfMemory)?;
                     table_size
                 } else {
                     0usize
@@ -630,7 +650,7 @@ impl StreamingDecoder {
                         .palette
                         .get_or_insert_with(Vec::new)
                         .try_reserve_exact(pal_len)
-                        .map_err(|_| io::ErrorKind::OutOfMemory)?;
+                        .map_err(|_| DecodingError::OutOfMemory)?;
                     goto!(consumed, LocalPalette(pal_len))
                 } else {
                     goto!(consumed, LocalPalette(0))
@@ -702,7 +722,7 @@ impl StreamingDecoder {
                     self.ext
                         .data
                         .try_reserve(n)
-                        .map_err(|_| io::Error::from(io::ErrorKind::OutOfMemory))?;
+                        .map_err(|_| DecodingError::OutOfMemory)?;
                     self.ext.data.extend_from_slice(&buf[..n]);
                     goto!(n, ExtensionDataBlock(left - n))
                 } else if b == 0 {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -210,7 +210,7 @@ impl<R: Read> ReadDecoder<R> {
             let (consumed, result) = {
                 let buf = self.reader.fill_buf()?;
                 if buf.is_empty() {
-                    return Err(io::ErrorKind::UnexpectedEof.into());
+                    return Err(DecodingError::UnexpectedEof);
                 }
 
                 self.decoder.update(buf, write_into)?
@@ -368,7 +368,7 @@ where
                             * usize::from(self.current_frame.height)
                             / 4,
                     )
-                    .map_err(|_| io::Error::from(io::ErrorKind::OutOfMemory))?;
+                    .map_err(|_| DecodingError::OutOfMemory)?;
                     self.copy_lzw_into_buffer(min_code_size, &mut vec)?;
                     self.current_frame.buffer = Cow::Owned(vec);
                 }


### PR DESCRIPTION
# Objective

`no_std` will require independence from `std::io::Error`. Several usages could be trivially replaced by expanding `DecodingError` and `EncodingError` to include more specific error types. Additionally, `LzwReader::decode_bytes` currently fails if the output buffer is of type `OutputBuffer::Vec`, it'd be better for that code-path to be implemented.

## Solution

- [Breaking] Marked `DecodingError` and `EncodingError` as `non_exhaustive` to accommodate possible future changes in a non-breaking way.
- [Breaking] Added extra variants to both enums to reduce usage of `std::io::Error` and provide more detailed error information to consumers.
- [Feature] Implemented `OutputBuffer::Vec` path of `LzwReader::decode_bytes` using `Decoder::into_vec`.