### PR TITLE
Include `clippy` in CI & Explicitly Use `std`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         override: true
+        components: clippy
     - name: build
       run: >
         cargo build --verbose --no-default-features --features "$FEATURES"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     - name: clippy
       run: >
         cargo clippy --verbose --no-default-features --features "$FEATURES"
-      if: ${{ matrix.rust == '1.62.0' }}
+      if: ${{ matrix.rust == 'stable' }}
     - name: test
       run: >
         cargo test --tests --benches --no-default-features --features "$FEATURES"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,9 @@ jobs:
     - name: build
       run: >
         cargo build --verbose --no-default-features --features "$FEATURES"
+    - name: clippy
+      run: >
+        cargo clippy --verbose --no-default-features --features "$FEATURES"
     - name: test
       run: >
         cargo test --tests --benches --no-default-features --features "$FEATURES"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
     - name: clippy
       run: >
         cargo clippy --verbose --no-default-features --features "$FEATURES"
+      if: ${{ matrix.rust == '1.62.0' }}
     - name: test
       run: >
         cargo test --tests --benches --no-default-features --features "$FEATURES"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         cargo build --verbose --no-default-features --features "$FEATURES"
     - name: clippy
       run: >
-        cargo clippy --verbose --no-default-features --features "$FEATURES"
+        cargo clippy --verbose --all-targets --no-default-features --features "$FEATURES"
       if: ${{ matrix.rust == 'stable' }}
     - name: test
       run: >

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,15 @@ required-features = ["std"]
 name = "rgb_frame"
 harness = false
 required-features = ["std", "color_quant"]
+
+[[example]]
+name = "check"
+required-features = ["std"]
+
+[[example]]
+name = "explode"
+required-features = ["std"]
+
+[[example]]
+name = "parallel"
+required-features = ["std"]

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -8,10 +8,14 @@ fn read_image(image: &[u8]) -> Option<Vec<u8>> {
     //decoder.set_param(gif::ColorOutput::RGBA);
     let mut reader = decoder.unwrap();
 
-    let mut v = vec![0; reader.buffer_size()];
-    reader.fill_buffer(&mut v).unwrap();
+    if reader.next_frame_info().unwrap().is_some() {
+        let mut v = vec![0; reader.buffer_size()];
+        reader.fill_buffer(&mut v).unwrap();
 
-    Some(v)
+        Some(v)
+    } else {
+        None
+    }
 }
 
 fn read_metadata(image: &[u8]) {

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -8,6 +8,7 @@ fn read_image(image: &[u8]) -> Option<Vec<u8>> {
     //decoder.set_param(gif::ColorOutput::RGBA);
     let mut reader = decoder.unwrap();
 
+    #[expect(clippy::never_loop)]
     while reader.next_frame_info().unwrap().is_some() {
         let mut v = vec![0; reader.buffer_size()];
         reader.fill_buffer(&mut v).unwrap();

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -11,7 +11,6 @@ fn read_image(image: &[u8]) -> Option<Vec<u8>> {
     if reader.next_frame_info().unwrap().is_some() {
         let mut v = vec![0; reader.buffer_size()];
         reader.fill_buffer(&mut v).unwrap();
-
         Some(v)
     } else {
         None

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -8,13 +8,10 @@ fn read_image(image: &[u8]) -> Option<Vec<u8>> {
     //decoder.set_param(gif::ColorOutput::RGBA);
     let mut reader = decoder.unwrap();
 
-    #[expect(clippy::never_loop)]
-    while reader.next_frame_info().unwrap().is_some() {
-        let mut v = vec![0; reader.buffer_size()];
-        reader.fill_buffer(&mut v).unwrap();
-        return Some(v);
-    }
-    None
+    let mut v = vec![0; reader.buffer_size()];
+    reader.fill_buffer(&mut v).unwrap();
+
+    Some(v)
 }
 
 fn read_metadata(image: &[u8]) {

--- a/benches/rgb_frame.rs
+++ b/benches/rgb_frame.rs
@@ -38,9 +38,7 @@ fn main() {
             .bench_function(
                 path.file_name().unwrap().to_str().unwrap(),
                 |b| match info.color_type {
-                    png::ColorType::Rgb => {
-                        b.iter(|| Frame::from_rgb_speed(w, h, &mut buf[..size], 30))
-                    }
+                    png::ColorType::Rgb => b.iter(|| Frame::from_rgb_speed(w, h, &buf[..size], 30)),
                     png::ColorType::Rgba => {
                         b.iter(|| Frame::from_rgba_speed(w, h, &mut buf[..size], 30))
                     }
@@ -60,7 +58,7 @@ fn main() {
 
         let frame = match info.color_type {
             png::ColorType::Rgb => Frame::from_rgb(w, h, &buf[..size]),
-            png::ColorType::Rgba => Frame::from_rgba(w, h, &buf[..size]),
+            png::ColorType::Rgba => Frame::from_rgba(w, h, &mut buf[..size]),
             _ => continue,
         };
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# Note: Ensure this matches the value in Cargo.toml and in CI
+msrv = "1.62.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,6 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+
 #[cfg(feature = "color_quant")]
 use std::collections::{HashMap, HashSet};
 
@@ -397,8 +399,8 @@ impl Frame<'static> {
             width: self.width,
             height: self.height,
             interlaced: self.interlaced,
-            palette: std::mem::take(&mut self.palette),
-            buffer: std::mem::replace(&mut self.buffer, Cow::Borrowed(&[])),
+            palette: core::mem::take(&mut self.palette),
+            buffer: core::mem::replace(&mut self.buffer, Cow::Borrowed(&[])),
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,9 +1,11 @@
 //! # Minimal gif encoder
-use std::borrow::Cow;
+
+use alloc::borrow::Cow;
+use alloc::fmt;
+use alloc::vec::Vec;
 use std::error;
-use std::fmt;
 use std::io;
-use std::io::prelude::*;
+use std::io::Write;
 
 use weezl::{encode::Encoder as LzwEncoder, BitOrder};
 
@@ -559,6 +561,7 @@ impl<const N: usize> Buf<N> {
 
 #[test]
 fn error_cast() {
+    use alloc::boxed::Box;
     let _: Box<dyn error::Error> =
         EncodingError::from(EncodingFormatError::MissingColorPalette).into();
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -252,7 +252,7 @@ impl<W: Write> Encoder<W> {
         let writer = self
             .w
             .as_mut()
-            .ok_or(io::Error::from(io::ErrorKind::Unsupported))?;
+            .ok_or_else(|| io::Error::from(io::ErrorKind::Unsupported))?;
         Self::write_encoded_image_block(writer, &self.buffer)
     }
 
@@ -407,7 +407,7 @@ impl<W: Write> Encoder<W> {
         self.write_trailer()?;
         self.w
             .take()
-            .ok_or(io::Error::from(io::ErrorKind::Unsupported))
+            .ok_or_else(|| io::Error::from(io::ErrorKind::Unsupported))
     }
 
     /// Write the final tailer.
@@ -419,7 +419,7 @@ impl<W: Write> Encoder<W> {
     fn writer(&mut self) -> io::Result<&mut W> {
         self.w
             .as_mut()
-            .ok_or(io::Error::from(io::ErrorKind::Unsupported))
+            .ok_or_else(|| io::Error::from(io::ErrorKind::Unsupported))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@
 // ```
 #![deny(missing_docs)]
 #![cfg(feature = "std")]
+#![allow(unknown_lints)] // Certain lints only apply to later versions of Rust
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::new_without_default)]
 #![deny(clippy::alloc_instead_of_core)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,14 @@
 #![cfg(feature = "std")]
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::new_without_default)]
+#![deny(clippy::alloc_instead_of_core)]
+#![deny(clippy::std_instead_of_alloc)]
+#![deny(clippy::std_instead_of_core)]
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate std;
 
 mod common;
 mod encoder;

--- a/src/reader/converter.rs
+++ b/src/reader/converter.rs
@@ -1,11 +1,12 @@
-use crate::common::Frame;
-use crate::MemoryLimit;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use core::iter;
+use core::mem;
 use std::io;
-use std::iter;
-use std::mem;
 
 use super::decoder::{DecodingError, OutputBuffer, PLTE_CHANNELS};
+use crate::common::Frame;
+use crate::MemoryLimit;
 
 pub(crate) const N_CHANNELS: usize = 4;
 
@@ -250,6 +251,8 @@ impl iter::Iterator for InterlaceIterator {
 
 #[cfg(test)]
 mod test {
+    use alloc::vec::Vec;
+
     use super::InterlaceIterator;
 
     #[rustfmt::skip]

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -1,11 +1,13 @@
-use std::borrow::Cow;
-use std::cmp;
-use std::default::Default;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::fmt;
+use alloc::vec::Vec;
+use core::cmp;
+use core::default::Default;
+use core::mem;
+use core::num::NonZeroUsize;
 use std::error;
-use std::fmt;
 use std::io;
-use std::mem;
-use std::num::NonZeroUsize;
 
 use crate::common::{AnyExtension, Block, DisposalMethod, Extension, Frame};
 use crate::reader::DecodeOptions;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -446,7 +446,7 @@ where
     pub fn palette(&self) -> Result<&[u8], DecodingError> {
         Ok(match self.current_frame.palette {
             Some(ref table) => table,
-            None => self.global_palette().ok_or(DecodingError::format(
+            None => self.global_palette().ok_or_else(|| DecodingError::format(
                 "no color table available for current frame",
             ))?,
         })

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -446,9 +446,9 @@ where
     pub fn palette(&self) -> Result<&[u8], DecodingError> {
         Ok(match self.current_frame.palette {
             Some(ref table) => table,
-            None => self.global_palette().ok_or_else(|| DecodingError::format(
-                "no color table available for current frame",
-            ))?,
+            None => self.global_palette().ok_or_else(|| {
+                DecodingError::format("no color table available for current frame")
+            })?,
         })
     }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,11 +1,11 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use core::convert::{TryFrom, TryInto};
+use core::iter::FusedIterator;
+use core::mem;
+use core::num::NonZeroU64;
 use std::io;
-use std::iter::FusedIterator;
-use std::mem;
-
-use std::convert::{TryFrom, TryInto};
 use std::io::prelude::*;
-use std::num::NonZeroU64;
 
 use crate::common::{Block, Frame};
 use crate::Repeat;

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -145,6 +145,7 @@ pub struct Crc32 {
 
 impl Crc32 {
     /// Create a new hasher.
+    #[expect(clippy::new_without_default)]
     pub fn new() -> Crc32 {
         Crc32 { crc: 0xFFFFFFFF }
     }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "std")]
 
-use gif::{AnyExtension, ColorOutput, DecodeOptions, Decoder, Encoder, Frame};
+use gif::{AnyExtension, DecodeOptions, Decoder, Encoder, Frame};
+
+#[cfg_attr(not(feature = "color_quant"), expect(unused_imports))]
+use gif::ColorOutput;
 
 #[test]
 fn round_trip() {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -25,10 +25,12 @@ fn round_trip() {
 #[test]
 fn max_frame_size() {
     let mut encoder = Encoder::new(vec![], 0xFFFF, 0xFFFF, &[1, 2, 3]).unwrap();
-    let mut f = Frame::default();
-    f.width = 0xFFFF;
-    f.height = 0xFFFF;
-    f.buffer = [5][..].into();
+    let f = Frame {
+        width: 0xFFFF,
+        height: 0xFFFF,
+        buffer: [5][..].into(),
+        ..Default::default()
+    };
     encoder.write_lzw_pre_encoded_frame(&f).unwrap();
     let res = encoder.into_inner().unwrap();
     let mut decoder = Decoder::new(&res[..]).unwrap();
@@ -165,17 +167,21 @@ fn palette_sizes() {
         let local = &local_pal[..size * 3];
 
         let mut encoder = Encoder::new(vec![], 1, 1, global).unwrap();
-        let mut f = Frame::default();
-        f.width = 1;
-        f.height = 1;
-        f.buffer = [1][..].into();
+        let f = Frame {
+            width: 1,
+            height: 1,
+            buffer: [1][..].into(),
+            ..Default::default()
+        };
         encoder.write_frame(&f).unwrap();
 
-        let mut f = Frame::default();
-        f.width = 1;
-        f.height = 1;
-        f.buffer = [1][..].into();
-        f.palette = Some(local.to_vec());
+        let f = Frame {
+            width: 1,
+            height: 1,
+            buffer: [1][..].into(),
+            palette: Some(local.to_vec()),
+            ..Default::default()
+        };
         encoder.write_frame(&f).unwrap();
         let gif = encoder.into_inner().unwrap();
         let gif = &mut gif.as_slice();
@@ -206,10 +212,12 @@ fn palette_sizes() {
 #[test]
 fn palette_fail() {
     let mut encoder = Encoder::new(vec![], 0xFFFF, 0xFFFF, &[]).unwrap();
-    let mut f = Frame::default();
-    f.width = 1;
-    f.height = 1;
-    f.buffer = [1][..].into();
+    let f = Frame {
+        width: 1,
+        height: 1,
+        buffer: [1][..].into(),
+        ..Default::default()
+    };
     assert!(matches!(
         encoder.write_frame(&f),
         Err(gif::EncodingError::Format(

--- a/tests/stall.rs
+++ b/tests/stall.rs
@@ -64,6 +64,8 @@ fn test_truncated_file() {
 
 #[track_caller]
 fn decode_chopped_anim(r: ChoppedReader) {
+    #[expect(clippy::suspicious_map)]
+    #[expect(clippy::expect_fun_call)]
     let frames = gif::DecodeOptions::new()
         .read_info(r)
         .unwrap()


### PR DESCRIPTION
# Objective

Several `clippy` lints can be quite useful for a consistent cooperative development experience. One such set of lints help with reducing reliance on `std`. It should be checked in CI.

## Solution

- Add `clippy` to CI (exclusively for MSRV to avoid new Rust versions adding lints causing retroactive CI failures)
- Added `#![no_std]` but re-added it via `extern crate std` to remove implicit `std` usage.
- Acted on `stable` and MSRV Clippy lints