### PR TITLE
Use `{int}::to_le_bytes` in `WriteBytesExt`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,22 +24,20 @@ impl<W: io::Write + ?Sized> WriteBytesExt<u8> for W {
 impl<W: io::Write + ?Sized> WriteBytesExt<u16> for W {
     #[inline]
     fn write_le(&mut self, n: u16) -> io::Result<()> {
-        self.write_all(&[n as u8, (n >> 8) as u8])
+        self.write_all(&n.to_le_bytes())
     }
 }
 
 impl<W: io::Write + ?Sized> WriteBytesExt<u32> for W {
     #[inline]
     fn write_le(&mut self, n: u32) -> io::Result<()> {
-        self.write_le(n as u16)?;
-        self.write_le((n >> 16) as u16)
+        self.write_all(&n.to_le_bytes())
     }
 }
 
 impl<W: io::Write + ?Sized> WriteBytesExt<u64> for W {
     #[inline]
     fn write_le(&mut self, n: u64) -> io::Result<()> {
-        self.write_le(n as u32)?;
-        self.write_le((n >> 32) as u32)
+        self.write_all(&n.to_le_bytes())
     }
 }


### PR DESCRIPTION
# Objective

`WriteBytesExt` currently uses a hand-rolled bit-shifting algorithm to divide and conquer unsized integers into little-endian bytes, before passing them to `Write::write_all`. While the implementation is correct, `core` provides `{int}::to_le_bytes`, which may optimise better (since it more clearly conveys intent to the optimiser), and is definitely more likely to be tested and maintained.

## Solution

- Switched to `{int}::to_le_bytes` for the implementations of `WriteBytesExt::write_le`