### PR TITLE
Pin to `weezl` 0.1.8 to resolve CI test failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.62"
 bench = false
 
 [dependencies]
-weezl = "0.1.8"
+weezl = "=0.1.8" # TODO: Fix compatibility with 0.1.9
 color_quant = { version = "1.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
# Objective

CI currently [fails](https://github.com/image-rs/image-gif/pull/205#issuecomment-2881859870) for a reason seemingly unrelated to the PR itself. I have diagnosed the issue as likely being caused by `weezl` 0.1.9. I verified this by using `cargo update --precise` to toggle between 0.1.8 and 0.1.9 and could observe the test failures on 0.1.9, and passed on 0.1.8.

## Solution

- Temporarily pinned to 0.1.8 so development here can continue while a long-term fix is investigated (either upstream if the break is unintentional, or here otherwise)