### PR TITLE
Switched to `BTreeMap` and `BTreeSet`

### DIFF
--- a/benches/rgb_frame.rs
+++ b/benches/rgb_frame.rs
@@ -60,7 +60,7 @@ fn main() {
 
         let frame = match info.color_type {
             png::ColorType::Rgb => Frame::from_rgb(w, h, &buf[..size]),
-            png::ColorType::Rgba => Frame::from_rgba(w, h, &buf[..size]),
+            png::ColorType::Rgba => Frame::from_rgba(w, h, &mut buf[..size]),
             _ => continue,
         };
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 #[cfg(feature = "color_quant")]
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Disposal method
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -227,7 +227,7 @@ impl Frame<'static> {
 
         // Attempt to build a palette of all colors. If we go over 256 colors,
         // switch to the NeuQuant algorithm.
-        let mut colors: HashSet<(u8, u8, u8, u8)> = HashSet::new();
+        let mut colors: BTreeSet<(u8, u8, u8, u8)> = BTreeSet::new();
         for pixel in pixels.chunks_exact(4) {
             if colors.insert((pixel[0], pixel[1], pixel[2], pixel[3])) && colors.len() > 256 {
                 // > 256 colours, let's use NeuQuant.
@@ -256,7 +256,7 @@ impl Frame<'static> {
             .iter()
             .flat_map(|&(r, g, b, _a)| [r, g, b])
             .collect();
-        let colors_lookup: HashMap<(u8, u8, u8, u8), u8> =
+        let colors_lookup: BTreeMap<(u8, u8, u8, u8), u8> =
             colors_vec.into_iter().zip(0..=255).collect();
 
         let index_of = |pixel: &[u8]| {


### PR DESCRIPTION
# Objective

For `no_std` compatibility it would be useful to move away from `HashMap` and `HashSet`, and instead use either [`hashbrown`](https://crates.io/crates/hashbrown) or `alloc::collections::BTreeMap`/`Set`. Since the cases where `HashMap` and `HashSet` are used are compatible with `BTreeMap` and `BTreeSet`, we should use those instead of introducing a new dependency.

## Solution

- Replaced `std::collections::HashMap` with `alloc::collections::BTreeMap`
- Replaced `std::collections::HashSet` with `alloc::collections::BTreeSet`
- Confirmed no performance change using `cargo bench rgb_frame` (the only benchmark that hits this code-path).

---

## Notes

On my Intel i5-1240p laptop I observed no difference in performance due to this PR:

```
rgb_frame/test.png      time:   [43.728 ms 44.277 ms 44.856 ms]
                        thrpt:  [116.15 MiB/s 117.67 MiB/s 119.15 MiB/s]
                 change:
                        time:   [-1.9516% -0.2032% +1.6099%] (p = 0.82 > 0.05)
                        thrpt:  [-1.5844% +0.2036% +1.9904%]
                        No change in performance detected.
```

It's possible other platforms may show a more pronounced performance delta, but without evidence I think the tradeoff between _possible_ performance loss vs increased platform compatibility is worth it here.