### PR TITLE
Update to edition 2024, MSRV 1.85

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,14 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.62.0", stable, beta, nightly]
+        rust: ["1.85.0", stable, beta, nightly]
         features: ["", "std", "color_quant"]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        override: true
         components: clippy
     - name: build
       run: >
@@ -28,22 +27,16 @@ jobs:
     - name: test
       run: >
         cargo test --tests --benches --no-default-features --features "$FEATURES"
-      if: ${{ matrix.rust != '1.62.0' }}
+      if: ${{ matrix.rust != '1.85.0' }}
       env:
         FEATURES: ${{ matrix.features }}
   rustfmt:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
         components: rustfmt
     - name: Run rustfmt check
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
-
+      run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ readme = "README.md"
 homepage = "https://github.com/image-rs/image-gif"
 repository = "https://github.com/image-rs/image-gif"
 documentation = "https://docs.rs/gif"
-edition = "2021"
+edition = "2024"
 include = ["src/**", "LICENSE-*", "README.md", "benches/*.rs"]
-rust-version = "1.62"
+rust-version = "1.85"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/image-rs/image-gif"
 repository = "https://github.com/image-rs/image-gif"
 documentation = "https://docs.rs/gif"
 edition = "2024"
+resolver = "2"
 include = ["src/**", "LICENSE-*", "README.md", "benches/*.rs"]
 rust-version = "1.85"
 

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -1,4 +1,4 @@
-use criterion::{measurement::Measurement, BenchmarkGroup, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, Throughput, measurement::Measurement};
 use gif::Decoder;
 use std::hint::black_box;
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,0 @@
-# Note: Ensure this matches the value in Cargo.toml and in CI
-msrv = "1.85.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
 # Note: Ensure this matches the value in Cargo.toml and in CI
-msrv = "1.62.0"
+msrv = "1.85.0"

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -1,7 +1,7 @@
 //! Reencodes GIF in parallel
 
-use gif::streaming_decoder::FrameDecoder;
 use gif::DecodeOptions;
+use gif::streaming_decoder::FrameDecoder;
 use rayon::iter::ParallelBridge;
 use rayon::iter::ParallelIterator;
 use std::env;

--- a/src/common.rs
+++ b/src/common.rs
@@ -213,7 +213,11 @@ impl Frame<'static> {
     #[cfg(feature = "color_quant")]
     #[track_caller]
     pub fn from_rgba_speed(width: u16, height: u16, pixels: &mut [u8], speed: i32) -> Self {
-        assert_eq!(width as usize * height as usize * 4, pixels.len(), "Too much or too little pixel data for the given width and height to create a GIF Frame");
+        assert_eq!(
+            width as usize * height as usize * 4,
+            pixels.len(),
+            "Too much or too little pixel data for the given width and height to create a GIF Frame"
+        );
         assert!(
             speed >= 1 && speed <= 30,
             "speed needs to be in the range [1, 30]"
@@ -296,7 +300,11 @@ impl Frame<'static> {
     /// # Panics:
     /// *   If the length of pixels does not equal `width * height * 2`.
     pub fn from_grayscale_with_alpha(width: u16, height: u16, pixels: &[u8]) -> Self {
-        assert_eq!(width as usize * height as usize * 2, pixels.len(), "Too much or too little pixel data for the given width and height to create a GIF Frame");
+        assert_eq!(
+            width as usize * height as usize * 2,
+            pixels.len(),
+            "Too much or too little pixel data for the given width and height to create a GIF Frame"
+        );
 
         // Input is in LumaA format.
         // Count the occurrences of all the colors, then pick the least common color as alpha.
@@ -333,7 +341,7 @@ impl Frame<'static> {
         let least_used_color = color_frequencies
             .iter()
             .enumerate()
-            .min_by_key(|(_, &value)| value)
+            .min_by_key(|&(_, &value)| value)
             .map(|(index, _)| index as u8)
             .expect("input slice is empty");
 
@@ -474,7 +482,11 @@ impl Frame<'static> {
     #[must_use]
     #[track_caller]
     pub fn from_rgb_speed(width: u16, height: u16, pixels: &[u8], speed: i32) -> Self {
-        assert_eq!(width as usize * height as usize * 3, pixels.len(), "Too much or too little pixel data for the given width and height to create a GIF Frame");
+        assert_eq!(
+            width as usize * height as usize * 3,
+            pixels.len(),
+            "Too much or too little pixel data for the given width and height to create a GIF Frame"
+        );
         let mut vec: Vec<u8> = Vec::new();
         vec.try_reserve_exact(pixels.len() + width as usize * height as usize)
             .expect("OOM");

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -7,7 +7,7 @@ use std::error;
 use std::io;
 use std::io::Write;
 
-use weezl::{encode::Encoder as LzwEncoder, BitOrder};
+use weezl::{BitOrder, encode::Encoder as LzwEncoder};
 
 use crate::common::{AnyExtension, Block, DisposalMethod, Extension, Frame};
 use crate::traits::WriteBytesExt;
@@ -201,7 +201,7 @@ impl<W: Write> Encoder<W> {
     pub fn write_frame(&mut self, frame: &Frame<'_>) -> Result<(), EncodingError> {
         if usize::from(frame.width)
             .checked_mul(usize::from(frame.height))
-            .map_or(true, |size| frame.buffer.len() < size)
+            .is_none_or(|size| frame.buffer.len() < size)
         {
             return Err(EncodingError::FrameBufferTooSmallForDimensions);
         }
@@ -235,7 +235,7 @@ impl<W: Write> Encoder<W> {
             _ => {
                 return Err(EncodingError::from(
                     EncodingFormatError::MissingColorPalette,
-                ))
+                ));
             }
         };
         let mut tmp = tmp_buf::<10>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,14 +142,7 @@ pub mod streaming_decoder {
     pub use crate::reader::{Decoded, FrameDataType, FrameDecoder, OutputBuffer, StreamingDecoder};
 }
 
-#[cfg(feature = "color_quant")]
-macro_rules! insert_as_doc {
-    { $content:expr } => {
-        #[allow(unused_doc_comments)]
-        #[doc = $content] extern "C" { }
-    }
-}
-
 // Provides the README.md as doc, to ensure the example works!
-#[cfg(feature = "color_quant")]
-insert_as_doc!(include_str!("../README.md"));
+#[cfg(all(doctest, feature = "color_quant"))]
+#[doc = include_str!("../README.md")]
+mod _readme {}

--- a/src/reader/converter.rs
+++ b/src/reader/converter.rs
@@ -4,8 +4,8 @@ use core::iter;
 use core::mem;
 
 use super::decoder::{DecodingError, OutputBuffer, PLTE_CHANNELS};
-use crate::common::Frame;
 use crate::MemoryLimit;
+use crate::common::Frame;
 
 pub(crate) const N_CHANNELS: usize = 4;
 
@@ -148,11 +148,7 @@ impl PixelConverter {
                                     rgba[1] = colors[1];
                                     rgba[2] = colors[2];
                                     rgba[3] = if let Some(t) = transparent {
-                                        if t == idx {
-                                            0x00
-                                        } else {
-                                            0xFF
-                                        }
+                                        if t == idx { 0x00 } else { 0xFF }
                                     } else {
                                         0xFF
                                     };

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -10,11 +10,11 @@ use core::num::NonZeroUsize;
 use std::error;
 use std::io;
 
+use crate::MemoryLimit;
 use crate::common::{AnyExtension, Block, DisposalMethod, Extension, Frame};
 use crate::reader::DecodeOptions;
-use crate::MemoryLimit;
 
-use weezl::{decode::Decoder as LzwDecoder, BitOrder, LzwError, LzwStatus};
+use weezl::{BitOrder, LzwError, LzwStatus, decode::Decoder as LzwDecoder};
 
 /// GIF palettes are RGB
 pub const PLTE_CHANNELS: usize = 3;
@@ -314,7 +314,7 @@ impl LzwReader {
     }
 
     pub fn has_ended(&self) -> bool {
-        self.decoder.as_ref().map_or(true, |e| e.has_ended())
+        self.decoder.as_ref().is_none_or(|e| e.has_ended())
     }
 
     pub fn decode_bytes(

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -15,7 +15,7 @@ mod decoder;
 
 pub use self::decoder::{
     Decoded, DecodingError, DecodingFormatError, FrameDataType, FrameDecoder, OutputBuffer,
-    StreamingDecoder, Version, PLTE_CHANNELS,
+    PLTE_CHANNELS, StreamingDecoder, Version,
 };
 
 pub use self::converter::ColorOutput;
@@ -347,7 +347,7 @@ where
                 None => {
                     return Err(DecodingError::format(
                         "file does not contain any image data",
-                    ))
+                    ));
                 }
             }
         }

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
 
-use std::io::prelude::*;
 use std::io::BufReader;
+use std::io::prelude::*;
 
 const BASE_PATH: [&str; 2] = [".", "tests"];
 

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "std")]
 
 use gif::{
-    streaming_decoder::{Decoded, OutputBuffer, StreamingDecoder},
     DecodeOptions, Decoder, DisposalMethod, Encoder, Frame, Repeat,
+    streaming_decoder::{Decoded, OutputBuffer, StreamingDecoder},
 };
 use std::{fs::File, io::BufRead};
 


### PR DESCRIPTION
## Summary

- Update Rust edition from 2021 to 2024
- Bump MSRV from 1.62 to 1.85 (minimum for edition 2024)
- Modernize CI actions (`actions/checkout@v4`, `dtolnay/rust-toolchain`)
- Pin `resolver = "2"` to avoid edition 2024's v3 resolver default
- Delete `clippy.toml` (clippy reads `rust-version` from `Cargo.toml` since 1.64)

### Code changes required by edition 2024

1. **Doc-include macro**: The `extern "C" {}` hack for embedding README doctests doesn't work in edition 2024 (`unsafe extern` is now required, which conflicts with `#![forbid(unsafe_code)]`). Replaced with the standard `#[doc = include_str!("../README.md")] mod _readme {}` pattern.

2. **Binding mode**: Edition 2024 changes implicit reference binding in closures. `|(_, &value)|` becomes `|&(_, &value)|` in `min_by_key` (one occurrence in `common.rs`).

3. **`is_none_or`**: Applied clippy's suggestion to replace `map_or(true, ...)` with `is_none_or(...)` (stabilized in 1.82, two occurrences).

All 39 tests pass. `cargo msrv verify` confirms 1.85.0 compatibility.

## Discussion: consider going to 1.88 or 1.89

Since this is a large MSRV jump anyway (1.62 → 1.85), it may be worth going further. The `image` crate is already on MSRV 1.88, so any user pulling in `gif` through `image` already needs 1.88+.

### Case for 1.88

- **`[T]::as_chunks` / `as_rchunks`** — process pixel data in fixed-width chunks (3-byte RGB, 4-byte RGBA) without bounds checks or manual index math. Directly applicable to `from_rgba_speed`, `from_rgb_speed`, `from_grayscale_with_alpha`.
- **`let` chains** (edition 2024 only) — `if let Some(x) = a && let Some(y) = b` replaces nested `if let` ladders in parser code.
- **`image` is already there** — `image 0.25.10` requires 1.88, so the primary downstream consumer already demands it.

### Case for 1.89

1.89 is where Rust's SIMD story came together across four releases:

- **1.86**: `#[target_feature]` functions can be safe — composing SIMD code no longer needs `unsafe` at every call site between matching feature contexts.
- **1.87**: Most `std::arch` intrinsics (arithmetic, shuffle, compare, bitwise) are now safe inside `#[target_feature]` functions. Only pointer-based ops (`loadu`/`storeu`) remain `unsafe`.
- **1.88**: `as_chunks` gives zero-cost fixed-size array views into slices — exactly what safe SIMD loads need.
- **1.89**: **AVX-512 stabilized on stable Rust** — 22 target features, ~857 intrinsics, plus SHA-512/SM3/SM4. Runtime detection (`is_x86_feature_detected!("avx512f")`) works on stable. The entire AVX-512 family was previously locked behind nightly-only feature gates.

Together, these mean a crate on MSRV 1.89 can use `#![forbid(unsafe_code)]` while still doing SIMD dispatch — no `unsafe`, no nightly, no feature gates. This matters for the broader image-rs ecosystem as codecs move toward safe SIMD. See [archmage's MSRV rationale](https://github.com/imazen/archmage/blob/main/MSRV.md) for the full breakdown.

This PR targets 1.85 as the conservative baseline. Happy to bump to 1.88 or 1.89 if preferred.

## Test plan

- [x] `cargo test --all-features` — 39 tests pass
- [x] `cargo clippy --all-features` — clean (one pre-existing `if_same_then_else` warning)
- [x] `cargo msrv verify` — confirms 1.85.0
- [x] `cargo fmt --check` — clean
- [x] Tested top 20 reverse dependencies via `cargo-copter` — no regressions from the edition change itself