### PR TITLE
Tolerate GIFs missing the final trailer byte (0x3B)

### DIFF
--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -543,6 +543,13 @@ impl StreamingDecoder {
         self.version
     }
 
+    /// At a post-frame block boundary, with the next block introducer not yet
+    /// read. `BlockStart(_)` is excluded: the introducer is already read there,
+    /// so an EOF is a truncated block, not a missing trailer.
+    pub(crate) fn is_at_block_boundary(&self) -> bool {
+        matches!(self.state, BlockEnd)
+    }
+
     #[inline]
     fn next_state(
         &mut self,

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -214,6 +214,8 @@ struct ReadDecoder<R: Read> {
     reader: io::BufReader<R>,
     decoder: StreamingDecoder,
     at_eof: bool,
+    /// At least one frame fully decoded; gates missing-trailer tolerance.
+    any_frame_decoded: bool,
 }
 
 impl<R: Read> ReadDecoder<R> {
@@ -226,6 +228,12 @@ impl<R: Read> ReadDecoder<R> {
             let (consumed, result) = {
                 let buf = self.reader.fill_buf()?;
                 if buf.is_empty() {
+                    // Missing-trailer tolerance: clean EOF at a post-frame block
+                    // boundary is end-of-stream, not truncation.
+                    if self.any_frame_decoded && self.decoder.is_at_block_boundary() {
+                        self.at_eof = true;
+                        break;
+                    }
                     return Err(DecodingError::UnexpectedEof);
                 }
 
@@ -234,6 +242,10 @@ impl<R: Read> ReadDecoder<R> {
             self.reader.consume(consumed);
             match result {
                 Decoded::Nothing => (),
+                Decoded::DataEnd => {
+                    self.any_frame_decoded = true;
+                    return Ok(Some(Decoded::DataEnd));
+                }
                 Decoded::BlockStart(Block::Trailer) => {
                     self.at_eof = true;
                 }
@@ -315,6 +327,7 @@ where
                 reader: io::BufReader::new(reader),
                 decoder,
                 at_eof: false,
+                any_frame_decoded: false,
             },
             bg_color: None,
             pixel_converter: PixelConverter::new(options.color_output),

--- a/tests/missing_trailer.rs
+++ b/tests/missing_trailer.rs
@@ -1,0 +1,105 @@
+//! Tolerating GIFs missing the final trailer byte (`0x3B`).
+#![cfg(feature = "std")]
+
+use gif::{ColorOutput, DecodeOptions, DecodingError, DisposalMethod, Encoder, Frame};
+
+/// A valid, complete two-frame GIF (with the `0x3B` trailer).
+fn build_two_frame_gif() -> Vec<u8> {
+    let mut data = Vec::new();
+    {
+        let mut encoder = Encoder::new(&mut data, 2, 2, &[0, 0, 0, 255, 255, 255]).unwrap();
+
+        let mut frame = Frame {
+            delay: 1,
+            dispose: DisposalMethod::Any,
+            transparent: None,
+            needs_user_input: false,
+            top: 0,
+            left: 0,
+            width: 2,
+            height: 2,
+            interlaced: false,
+            palette: None,
+            buffer: vec![0, 1, 1, 0].into(),
+        };
+        encoder.write_frame(&frame).unwrap();
+
+        frame.buffer = vec![1, 0, 0, 1].into();
+        encoder.write_frame(&frame).unwrap();
+    }
+    data
+}
+
+fn decode_all(bytes: &[u8]) -> Result<Vec<Vec<u8>>, DecodingError> {
+    let mut options = DecodeOptions::new();
+    options.set_color_output(ColorOutput::Indexed);
+    let mut decoder = options.read_info(bytes)?;
+
+    let mut frames = Vec::new();
+    loop {
+        match decoder.read_next_frame()? {
+            Some(frame) => frames.push(frame.buffer.to_vec()),
+            None => return Ok(frames),
+        }
+    }
+}
+
+/// Index of the `n`th image separator (`0x2C`).
+fn nth_image_sep(gif: &[u8], n: usize) -> usize {
+    gif.iter()
+        .enumerate()
+        .filter(|&(_, &b)| b == 0x2C)
+        .nth(n)
+        .map(|(i, _)| i)
+        .expect("image separator not found")
+}
+
+fn is_truncation(err: DecodingError) -> bool {
+    matches!(err, DecodingError::UnexpectedEof | DecodingError::Truncated)
+}
+
+#[test]
+fn missing_trailer_decodes_all_frames_cleanly() {
+    let with_trailer = build_two_frame_gif();
+    assert_eq!(*with_trailer.last().unwrap(), 0x3B);
+
+    let trailerless = &with_trailer[..with_trailer.len() - 1];
+    let baseline = decode_all(&with_trailer).expect("with-trailer GIF must decode");
+    let stripped = decode_all(trailerless).expect("trailerless GIF must decode cleanly");
+
+    assert_eq!(baseline.len(), 2);
+    assert_eq!(stripped, baseline, "trailerless decode must match");
+}
+
+#[test]
+fn truncation_mid_frame_still_errors() {
+    let full = build_two_frame_gif();
+    // A few bytes into the second frame's LZW data.
+    let truncated = &full[..nth_image_sep(&full, 1) + 12];
+    assert!(is_truncation(
+        decode_all(truncated).expect_err("mid-frame truncation must error")
+    ));
+}
+
+/// The review fix: once the next introducer byte is read the decoder is
+/// mid-block, so EOF is truncation — even though a frame was already decoded.
+#[test]
+fn introducer_then_eof_after_frame_still_errors() {
+    let full = build_two_frame_gif();
+    // Right after the second image separator: frame one complete, `0x2C` read,
+    // its descriptor gone.
+    let truncated = &full[..nth_image_sep(&full, 1) + 1];
+    assert!(is_truncation(
+        decode_all(truncated).expect_err("introducer-then-EOF must error")
+    ));
+}
+
+#[test]
+fn zero_frames_then_eof_still_errors() {
+    let full = build_two_frame_gif();
+    let truncated = &full[..nth_image_sep(&full, 0) + 1];
+    assert!(
+        decode_all(truncated).is_err(),
+        "zero-frame truncation must error"
+    );
+}


### PR DESCRIPTION
## Problem

A surprising number of real-world GIFs omit the final trailer block (`0x3B`). **NB: This crate, if the encoder is not dropped before accessing the stream, *also* fails to emit the final trailer block. This is a consumer usage error but a light footgun I've personally run into.**  Browsers, ImageMagick, and PIL all decode them without complaint. Currently, after decoding every frame, the decoder hits EOF while looking for the next block introducer and surfaces `UnexpectedEof` — so a strict consumer (e.g. the `image` crate's collect path) rejects a fully-decodable GIF as corrupt.

### Concrete repro

A real 67-frame GIF in the wild ([example](https://user-images.githubusercontent.com/657201/139770827-18e25c4e-eb0a-4058-ba48-ddc3849090ee.gif), 1.97 MB, 260×342) ends with `0x00` (the block terminator of its last image sub-block) and has no `0x3B` trailer.

- `gif` 0.14.2 and current `master`: decode all **67 frames correctly** (RGBA buffers match ImageMagick / PIL), then return **`Err(UnexpectedEof)`**.
- ImageMagick and PIL both accept it (67 frames).

## Fix

This relaxes **only** the clean-boundary case: when the decoder is *between blocks* — the previous frame fully completed and the next byte it expects is a block introducer/trailer — and **at least one frame has been decoded**, a trailing EOF is reported as a clean end-of-stream (`Ok(None)`) instead of an error.

Concretely, in `ReadDecoder::decode_next`, when `fill_buf()` returns empty:

```rust
if self.any_frame_decoded && self.decoder.is_at_block_boundary() {
    self.at_eof = true;
    break; // clean end-of-stream
}
return Err(DecodingError::UnexpectedEof);
```

`is_at_block_boundary()` is true only for the `BlockStart(_)` / `BlockEnd` states (waiting for the next block introducer). `any_frame_decoded` is set when a frame's `Decoded::DataEnd` is observed.

### What still errors (zero-trust boundary)

- **EOF in the middle of a frame** (truncated image data / incomplete LZW sub-block / partial header) — genuine truncation → still `UnexpectedEof` / `Truncated`.
- **EOF before any frame** (zero-frames-then-EOF) — malformed → still errors.
- Any non-EOF error is unchanged.

This extends the same "accept non-terminated streams by cutting off when all bytes are decoded" philosophy [noted in #235](https://github.com/image-rs/image-gif/issues/235#issuecomment-4449385846) to the missing-end-trailer case. It mirrors a guard we ship downstream.

## Tests (`tests/missing_trailer.rs`)

- **Positive**: a valid two-frame GIF with the `0x3B` trailer stripped decodes **all** frames cleanly, pixel-identical to the with-trailer decode.
- **Negative (zero-trust)**: a GIF truncated *mid-frame* (frame 1 fully decodes, frame 2's data is cut) **still errors** — proving the relaxation doesn't open a truncation hole even after a complete frame.
- **Negative**: header-only / zero-frame-then-EOF **still errors**.

The full existing suite passes unchanged (trailer-present, truncation, stall/byte-at-a-time streaming).

## Notes

- No public API change (`is_at_block_boundary` is `pub(crate)`; `any_frame_decoded` is a private field).
- MSRV unchanged (1.85) — pure logic, no dependency change. Verified building + testing on 1.85.
- `cargo fmt` clean; `clippy` clean on the touched files.
