### PR TITLE
Proof of Concept: Demonstrate `no_std` support on nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.88.0", stable, beta, nightly]
+        rust: [nightly]
         features: ["", "std", "color_quant"]
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/gif"
 edition = "2024"
 resolver = "2"
 include = ["src/**", "LICENSE-*", "README.md", "benches/*.rs"]
-rust-version = "1.88"
+rust-version = "1.99"
 
 [lib]
 bench = false

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2,10 +2,10 @@
 
 use alloc::borrow::Cow;
 use alloc::fmt;
+use alloc::io;
+use alloc::io::Write;
 use alloc::vec::Vec;
-use std::error;
-use std::io;
-use std::io::Write;
+use core::error;
 
 use weezl::{BitOrder, encode::Encoder as LzwEncoder};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@
 // # })().unwrap();
 // ```
 #![deny(missing_docs)]
-#![cfg(feature = "std")]
 #![allow(unknown_lints)] // Certain lints only apply to later versions of Rust
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::new_without_default)]
@@ -118,10 +117,10 @@
 #![deny(clippy::std_instead_of_alloc)]
 #![deny(clippy::std_instead_of_core)]
 #![no_std]
+#![feature(alloc_io)]
 
 #[macro_use]
 extern crate alloc;
-extern crate std;
 
 mod common;
 mod encoder;

--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -7,8 +7,8 @@ use core::default::Default;
 use core::mem;
 use core::num::NonZeroUsize;
 
-use std::error;
-use std::io;
+use alloc::io;
+use core::error;
 
 use crate::MemoryLimit;
 use crate::common::{AnyExtension, Block, DisposalMethod, Extension, Frame};

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,11 +1,11 @@
 use alloc::borrow::Cow;
+use alloc::io;
+use alloc::io::prelude::*;
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 use core::iter::FusedIterator;
 use core::mem;
 use core::num::NonZeroU64;
-use std::io;
-use std::io::prelude::*;
 
 use crate::common::{Block, Frame};
 use crate::{AnyExtension, Extension, Repeat};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
 //! Traits used in this library
-use std::io;
+use alloc::io;
 
 /// Writer extension to write little endian data
 pub trait WriteBytesExt<T> {


### PR DESCRIPTION
# Description

Now that [rust-lang/rust#154046](https://github.com/rust-lang/rust/issues/154046) has been implemented, `std::io` is available through `alloc::io`. This PR demonstrates adding complete `no_std` support using the currently nightly (or a potential future stable version of Rust if/when `alloc_io` is stable). This is a substantially simpler effort than #200, while also providing more `no_std` functionality.

## Solution

- Enable `alloc_io` nightly feature
- Swap usage of `std::io` for `alloc::io`
- Swap usage of `std::error` for `core::error`
- Remove non-nightly CI tests (just to demonstrate success, since this PR is incompatible with any stable version Rust)

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.
- I am the main contributor to the `alloc_io` feature, and I'm opening this PR to demonstrate the it's utility.